### PR TITLE
Add dependency resolution, ALPM backend, and ratatui TUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "alpm"
+version = "5.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7b56a77dc29bbe3c1d2b2a073200b7a09ed0a5d0b421315e915abdee4e1f2b"
+dependencies = [
+ "alpm-sys",
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "alpm-sys"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2802ef5d74e47cceda08d0d583c69be2595a5d25e2d6eef349b5e5b5ed4560e9"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
+name = "alpm-utils"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a59a6ffb120311a82dd5569a3bfa0098db8a1c1d8b5ec568e97b61cff3b10729"
+dependencies = [
+ "alpm",
+ "pacmanconf",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,6 +130,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "archery"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e0a5f99dfebb87bb342d0f53bb92c81842e100bbb915223e38349580e5441d"
+dependencies = [
+ "triomphe",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,7 +152,29 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -125,7 +185,16 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -141,23 +210,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "bigdecimal"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
-dependencies = [
- "autocfg",
- "libm",
- "num-bigint",
- "num-integer",
- "num-traits",
-]
 
 [[package]]
 name = "bindgen"
@@ -165,7 +243,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -176,7 +254,16 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec 0.6.3",
 ]
 
 [[package]]
@@ -185,8 +272,14 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -196,25 +289,66 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bon"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47dbe92550676ee653353c310dfb9cf6ba17ee70396e1f7cf0a2020ad49b2fe"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
+dependencies = [
+ "darling 0.23.0",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "brush-core"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfb3aef6ccefeb0190a223cd9ef6dc7e79606d08dd5e178448e4cc42f79235c"
+checksum = "2a3ad2f2d4eb45ef7f11e74bc1a0816c8f3dce298072352c6b3b41a2c4bfdb74"
 dependencies = [
  "async-recursion",
  "async-trait",
+ "bon",
  "brush-parser",
  "cached",
  "cfg-if",
  "chrono",
  "clap",
  "command-fds",
- "fancy-regex",
+ "fancy-regex 0.16.2",
  "futures",
  "getrandom 0.3.4",
  "homedir",
@@ -223,17 +357,14 @@ dependencies = [
  "itertools 0.14.0",
  "nix 0.30.1",
  "normalize-path",
- "os_pipe",
- "procfs",
  "rand 0.9.2",
- "rlimit",
+ "rpds",
  "strum",
  "strum_macros",
  "terminfo",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
- "uucore",
  "uuid",
  "uzers",
  "whoami",
@@ -241,14 +372,15 @@ dependencies = [
 
 [[package]]
 name = "brush-parser"
-version = "0.2.17"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efe89f062a31fa711d5c1da149b907417fbe618269e883f28898b0b67e2c44bf"
+checksum = "f7367124d4f38fdcd65f4b815bda7caeb3de377b9cd95ffa1b23627989c93718"
 dependencies = [
+ "bon",
  "cached",
  "indenter",
  "peg",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "utf8-chars",
 ]
@@ -260,6 +392,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,29 +405,29 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cached"
-version = "0.55.1"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0839c297f8783316fcca9d90344424e968395413f0662a5481f79c6648bbc14"
+checksum = "801927ee168e17809ab8901d9f01f700cd7d8d6a6527997fee44e4b0327a253c"
 dependencies = [
  "ahash",
  "cached_proc_macro",
  "cached_proc_macro_types",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.5",
  "once_cell",
- "thiserror",
+ "thiserror 2.0.18",
  "web-time",
 ]
 
 [[package]]
 name = "cached_proc_macro"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673992d934f0711b68ebb3e1b79cdc4be31634b37c98f26867ced0438ca5c603"
+checksum = "9225bdcf4e4a9a4c08bf16607908eb2fbf746828d5e0b5e019726dbf6571f201"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -299,14 +437,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cexpr"
@@ -339,8 +494,14 @@ dependencies = [
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
+
+[[package]]
+name = "cini"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628d1f5b9a7b1196ce1aa660e3ba7e2559d350649cbe94993519c127df667f2"
 
 [[package]]
 name = "clang-sys"
@@ -385,7 +546,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -400,15 +561,27 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
+ "crossterm",
  "directories",
  "flate2",
  "koca",
+ "koca-proto",
+ "ratatui",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
  "tar",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "zolt",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -428,13 +601,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "command-fds"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f849b92c694fe237ecd8fafd1ba0df7ae0d45c1df6daeb7f68ed4220d51640bd"
 dependencies = [
  "nix 0.30.1",
- "thiserror",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -442,6 +658,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc32fast"
@@ -453,13 +678,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.11.1",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -473,7 +755,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -482,9 +777,67 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -516,8 +869,29 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "doctest-file"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
@@ -542,14 +916,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "fancy-regex"
-version = "0.14.0"
+name = "euclid"
+version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
- "bit-set",
+ "num-traits",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set 0.5.3",
+ "regex",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set 0.8.0",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]
@@ -570,6 +974,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,55 +996,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "fluent"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8137a6d5a2c50d6b0ebfcb9aaa91a28154e0a70605f112d30cb0cd4a78670477"
-dependencies = [
- "fluent-bundle",
- "unic-langid",
-]
-
-[[package]]
-name = "fluent-bundle"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01203cb8918f5711e73891b347816d932046f95f54207710bda99beaeb423bf4"
-dependencies = [
- "fluent-langneg",
- "fluent-syntax",
- "intl-memoizer",
- "intl_pluralrules",
- "rustc-hash",
- "self_cell",
- "smallvec",
- "unic-langid",
-]
-
-[[package]]
-name = "fluent-langneg"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eebbe59450baee8282d71676f3bfed5689aeab00b27545e83e5f14b1195e8b0"
-dependencies = [
- "unic-langid",
-]
-
-[[package]]
-name = "fluent-syntax"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54f0d287c53ffd184d04d8677f590f4ac5379785529e5e08b1c8083acdd5c198"
-dependencies = [
- "memchr",
- "thiserror",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -638,6 +1021,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -695,7 +1084,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -728,6 +1117,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -749,9 +1148,22 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -762,12 +1174,13 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "ahash",
  "allocator-api2",
+ "equivalent",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -775,6 +1188,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -790,12 +1208,12 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "homedir"
-version = "0.3.6"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68df315d2857b2d8d2898be54a85e1d001bbbe0dbb5f8ef847b48dd3a23c4527"
+checksum = "5bdbbd5bc8c5749697ccaa352fa45aff8730cf21c68029c0eef1ffed7c3d6ba2"
 dependencies = [
  "cfg-if",
- "nix 0.30.1",
+ "nix 0.29.0",
  "widestring",
  "windows",
 ]
@@ -808,7 +1226,7 @@ checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -1017,6 +1435,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1057,25 +1481,45 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
-name = "intl-memoizer"
-version = "0.5.3"
+name = "indoc"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310da2e345f5eb861e7a07ee182262e94975051db9e4223e909ba90f392f163f"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
- "type-map",
- "unic-langid",
+ "rustversion",
 ]
 
 [[package]]
-name = "intl_pluralrules"
-version = "7.0.2"
+name = "instability"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
- "unic-langid",
+ "darling 0.23.0",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "interprocess"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "069323743400cb7ab06a8fe5c1ed911d36b6919ec531661d034c89083629595b"
+dependencies = [
+ "doctest-file",
+ "futures-core",
+ "libc",
+ "recvmsg",
+ "tokio",
+ "widestring",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1125,6 +1569,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1137,26 +1635,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "koca"
 version = "0.2.0"
 dependencies = [
  "brush-core",
  "brush-parser",
  "itertools 0.14.0",
+ "koca-proto",
+ "libversion",
  "nfpm-sys",
  "nix 0.29.0",
+ "repology",
  "semver",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
+ "tokio",
  "walkdir",
 ]
+
+[[package]]
+name = "koca-backend-alpm"
+version = "0.2.0"
+dependencies = [
+ "alpm",
+ "alpm-utils",
+ "anyhow",
+ "clap",
+ "koca-proto",
+ "pacmanconf",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "koca-proto"
+version = "0.2.0"
+dependencies = [
+ "clap",
+ "interprocess",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
 
 [[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1171,14 +1722,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-link",
 ]
-
-[[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -1186,17 +1731,29 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "libc",
  "plain",
- "redox_syscall",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
+name = "libversion"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "8407ff73cf44200c0bd56feda8766d7d1c01a98ff17af170a28565428d2142e0"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "line-clipping"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags 2.11.1",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1211,10 +1768,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
 
 [[package]]
 name = "lru-slab"
@@ -1223,10 +1804,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix 0.29.0",
+ "winapi",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -1251,6 +1857,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1268,10 +1875,11 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -1280,7 +1888,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1303,22 +1911,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5438dd2b2ff4c6df6e1ce22d825ed2fa93ee2922235cc45186991717f0a892d"
 
 [[package]]
-name = "num-bigint"
-version = "0.4.6"
+name = "num-conv"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
-name = "num-integer"
-version = "0.1.46"
+name = "num-derive"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
- "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1331,10 +1937,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "number_prefix"
-version = "0.4.0"
+name = "num_threads"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "once_cell"
@@ -1349,28 +1958,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
-name = "os_display"
-version = "0.1.4"
+name = "ordered-float"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad5fd71b79026fb918650dde6d125000a233764f1c2f1659a1c71118e33ea08f"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
- "unicode-width",
+ "num-traits",
 ]
 
 [[package]]
-name = "os_pipe"
-version = "1.2.3"
+name = "pacmanconf"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+checksum = "1087f8994e545eed9f7453376282f2964f18ca4b739e42f0dc7f2fed246d76c3"
 dependencies = [
+ "cini",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
  "libc",
- "windows-sys 0.61.2",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link",
 ]
 
 [[package]]
@@ -1407,11 +2044,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
+ "phf_macros",
  "phf_shared",
 ]
 
@@ -1436,6 +2117,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1457,10 +2151,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -1470,6 +2176,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1487,7 +2199,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1497,31 +2209,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "procfs"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
-dependencies = [
- "bitflags",
- "chrono",
- "flate2",
- "hex",
- "procfs-core",
- "rustix 0.38.44",
-]
-
-[[package]]
-name = "procfs-core"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
-dependencies = [
- "bitflags",
- "chrono",
- "hex",
 ]
 
 [[package]]
@@ -1538,7 +2225,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1550,6 +2237,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -1559,7 +2247,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1593,6 +2281,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1639,12 +2333,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+dependencies = [
+ "bitflags 2.11.1",
+ "compact_str",
+ "hashbrown 0.16.1",
+ "indoc",
+ "itertools 0.14.0",
+ "kasuari",
+ "lru",
+ "strum",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.16.1",
+ "indoc",
+ "instability",
+ "itertools 0.14.0",
+ "line-clipping",
+ "ratatui-core",
+ "strum",
+ "time",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "recvmsg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1655,7 +2449,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1686,6 +2480,24 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "repology"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ebf8aed878b7aee65969f12abe8ea1e492970b4defd338fe46b72a65682fed"
+dependencies = [
+ "async-stream",
+ "bon",
+ "futures-core",
+ "reqwest 0.13.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "url",
+]
 
 [[package]]
 name = "reqwest"
@@ -1726,6 +2538,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1740,12 +2590,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rlimit"
-version = "0.10.2"
+name = "rpds"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7043b63bd0cd1aaa628e476b80e6d4023a3b50eb32789f2728908107bd0c793a"
+checksum = "9e75f485e819d4d3015e6c0d55d02a4fd3db47c1993d9e603e0361fba2bffb34"
 dependencies = [
- "libc",
+ "archery",
 ]
 
 [[package]]
@@ -1755,16 +2605,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
-name = "rustix"
-version = "0.38.44"
+name = "rustc_version"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "semver",
 ]
 
 [[package]]
@@ -1773,10 +2619,10 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -1786,12 +2632,25 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -1805,11 +2664,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -1837,10 +2724,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "self_cell"
-version = "1.2.2"
+name = "schannel"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -1875,7 +2794,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1904,10 +2823,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -1960,6 +2911,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1970,6 +2927,9 @@ name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
 
 [[package]]
 name = "strum_macros"
@@ -1980,7 +2940,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1988,6 +2948,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -2017,7 +2988,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2037,7 +3008,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -2054,12 +3025,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitflags 2.11.1",
+ "fancy-regex 0.11.0",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix 0.29.0",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2070,8 +3112,29 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tinystr"
@@ -2080,7 +3143,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
- "serde_core",
  "zerovec",
 ]
 
@@ -2108,6 +3170,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -2123,7 +3186,7 @@ checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2133,6 +3196,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -2157,7 +3231,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -2200,7 +3274,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2213,37 +3287,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "triomphe"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd69c5aa8f924c7519d6372789a74eac5b94fb0f8fcf0d4a97eb0bfc3e785f39"
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "type-map"
-version = "0.5.1"
+name = "typenum"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
-dependencies = [
- "rustc-hash",
-]
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
-name = "unic-langid"
-version = "0.9.6"
+name = "ucd-trie"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28ba52c9b05311f4f6e62d5d9d46f094bd6e84cb8df7b3ef952748d752a7d05"
-dependencies = [
- "unic-langid-impl",
-]
-
-[[package]]
-name = "unic-langid-impl"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce1bf08044d4b7a94028c93786f8566047edc11110595914de93362559bc658"
-dependencies = [
- "tinystr",
-]
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
@@ -2252,10 +3317,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-truncate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+dependencies = [
+ "itertools 0.14.0",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -2297,50 +3385,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "uucore"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9032bf981784f22fcc5ddc7e74b7cf3bae3d5f44a48d2054138ed38068b9f4e0"
-dependencies = [
- "bigdecimal",
- "clap",
- "fluent",
- "fluent-bundle",
- "glob",
- "itertools 0.14.0",
- "nix 0.30.1",
- "num-traits",
- "number_prefix",
- "os_display",
- "thiserror",
- "unic-langid",
- "uucore_procs",
- "wild",
-]
-
-[[package]]
-name = "uucore_procs"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c933945fdac5b7779eae1fc746146e61f5b0298deb6ede002ce0b6e93e1b3bfc"
-dependencies = [
- "proc-macro2",
- "quote",
- "uuhelp_parser",
-]
-
-[[package]]
-name = "uuhelp_parser"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beda381dd5c7927f8682f50b055b0903bb694ba5a4b27fad1b4934bc4fbf7b8d"
-
-[[package]]
 name = "uuid"
 version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
+ "atomic",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -2360,6 +3411,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
 
 [[package]]
 name = "walkdir"
@@ -2391,6 +3451,15 @@ name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -2443,7 +3512,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -2454,6 +3523,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -2477,12 +3580,93 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
 ]
 
 [[package]]
@@ -2503,13 +3687,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
-name = "wild"
-version = "2.2.1"
+name = "winapi"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3131afc8c575281e1e80f36ed6a092aa502c08b18ed7524e86fbbb12bb410e1"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
- "glob",
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
 ]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
@@ -2521,38 +3712,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows"
-version = "0.61.3"
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
-dependencies = [
- "windows-collections",
- "windows-core 0.61.2",
- "windows-future",
- "windows-link 0.1.3",
- "windows-numerics",
-]
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-collections"
-version = "0.2.0"
+name = "windows"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.61.2"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2561,22 +3745,22 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.2.1",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link",
  "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-strings",
 ]
 
 [[package]]
-name = "windows-future"
-version = "0.2.1"
+name = "windows-implement"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
- "windows-threading",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2587,7 +3771,18 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2598,14 +3793,8 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
-
-[[package]]
-name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-link"
@@ -2614,22 +3803,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
-]
-
-[[package]]
 name = "windows-result"
-version = "0.3.4"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2638,16 +3817,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -2656,7 +3826,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -2692,7 +3871,22 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -2717,7 +3911,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -2729,13 +3923,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-threading"
-version = "0.1.0"
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
-dependencies = [
- "windows-link 0.1.3",
-]
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2751,6 +3942,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2760,6 +3957,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2787,6 +3990,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2796,6 +4005,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2811,6 +4026,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -2820,6 +4041,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2838,6 +4065,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.1",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
@@ -2852,7 +4161,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix 1.1.4",
+ "rustix",
 ]
 
 [[package]]
@@ -2874,7 +4183,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -2895,7 +4204,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2915,7 +4224,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -2942,7 +4251,6 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
- "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",
@@ -2956,7 +4264,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,12 @@
 [workspace]
 resolver = "2"
-members = ["crates/koca", "crates/cli", "crates/nfpm-sys"]
+members = [
+    "crates/koca",
+    "crates/cli",
+    "crates/nfpm-sys",
+    "crates/proto",
+    "crates/backends/alpm",
+]
 
 [workspace.package]
 version = "0.2.0"
@@ -9,8 +15,8 @@ repository = "https://github.com/koca-build/koca"
 
 [workspace.dependencies]
 anyhow = "1.0.98"
-brush = { package = "brush-core", version = "=0.3.2" }
-brush-parser = "=0.2.17"
+brush = { package = "brush-core", version = "=0.4.0" }
+brush-parser = "=0.3.0"
 clap = { version = "4.5.37", features = ["derive", "env"] }
 directories = "6.0.0"
 flate2 = "1.1.2"
@@ -19,7 +25,8 @@ nfpm-sys = { path = "crates/nfpm-sys" }
 semver = "1.0.26"
 thiserror = "2.0.12"
 tar = "0.4.44"
-tokio = "1.45.0"
+tokio = { version = "1.45.0", features = ["full"] }
+repology = "0.1.1"
 zolt = "0.7.2"
 regex = "1.11.1"
 reqwest = { version = "0.12.19", default-features = false, features = [
@@ -29,3 +36,8 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 nix = { version = "0.29", features = ["user"] }
 walkdir = "2.5.0"
+interprocess = { version = "2", features = ["tokio"] }
+koca-proto = { path = "crates/proto" }
+libversion = "0.3.1"
+ratatui = "0.30"
+crossterm = "0.29"

--- a/crates/backends/alpm/Cargo.toml
+++ b/crates/backends/alpm/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "koca-backend-alpm"
+version.workspace = true
+edition.workspace = true
+description = "Arch Linux backend for Koca"
+license = "GPL-3.0"
+
+[[bin]]
+name = "koca-backend-alpm"
+path = "src/main.rs"
+
+[dependencies]
+koca-proto = { workspace = true }
+alpm = "5.0.2"
+alpm-utils = "5.0.0"
+pacmanconf = "3.1.0"
+anyhow = { workspace = true }
+clap = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }

--- a/crates/backends/alpm/src/handler.rs
+++ b/crates/backends/alpm/src/handler.rs
@@ -1,0 +1,439 @@
+use alpm::{
+    Alpm, AnyDownloadEvent, AnyEvent, DownloadEvent, DownloadResult, Error as AlpmError, Event,
+    PackageReason, Progress, TransFlag,
+};
+use koca_proto::{
+    ActionKind, BackendSession, DownloadEvent as ProtoDownloadEvent, ErrorCode,
+    Event as ProtoEvent, InstallEvent as ProtoInstallEvent, InstalledStatus, Message, MessageBody,
+    PackageStatus, PlannedAction, ProtocolError, RemoveEvent as ProtoRemoveEvent, ResultPayload,
+};
+use tokio::sync::mpsc;
+
+/// Open an ALPM handle configured from the system's pacman.conf.
+fn open_handle() -> Result<Alpm, String> {
+    let conf = pacmanconf::Config::new().map_err(|e| e.to_string())?;
+    alpm_utils::alpm_with_conf(&conf).map_err(|e| e.to_string())
+}
+
+/// Returns `true` if the ALPM error indicates a permission problem.
+fn is_permission_error(e: &AlpmError) -> bool {
+    matches!(e, AlpmError::HandleLock | AlpmError::DbOpen)
+        || e.to_string().to_lowercase().contains("permission")
+        || e.to_string().to_lowercase().contains("access")
+}
+
+// ── check-installed ───────────────────────────────────────────────────────
+
+pub fn check_installed(packages: &[String]) -> Result<ResultPayload, ProtocolError> {
+    let handle = open_handle().map_err(|e| ProtocolError {
+        code: ErrorCode::Internal,
+        message: e,
+    })?;
+
+    let local = handle.localdb();
+    let statuses = packages
+        .iter()
+        .map(|name| match local.pkg(name.as_str()) {
+            Ok(pkg) => PackageStatus {
+                name: name.clone(),
+                status: InstalledStatus::Installed,
+                version: Some(pkg.version().to_string()),
+                is_auto: Some(pkg.reason() == PackageReason::Depend),
+            },
+            Err(_) => PackageStatus {
+                name: name.clone(),
+                status: InstalledStatus::Missing,
+                version: None,
+                is_auto: None,
+            },
+        })
+        .collect();
+
+    Ok(ResultPayload::CheckInstalled { packages: statuses })
+}
+
+// ── install-plan ──────────────────────────────────────────────────────────
+
+/// Build an install plan.
+///
+/// Returns `(plan_payload, resolved_package_names)`.
+/// The resolved names may differ from the input if `find_satisfier` returned a
+/// different package (e.g. a virtual provider).
+pub fn install_plan(packages: &[String]) -> Result<(ResultPayload, Vec<String>), ProtocolError> {
+    let mut handle = open_handle().map_err(|e| ProtocolError {
+        code: ErrorCode::Internal,
+        message: e,
+    })?;
+
+    handle
+        .trans_init(TransFlag::NEEDED | TransFlag::NO_LOCK)
+        .map_err(|e| {
+            if is_permission_error(&e) {
+                ProtocolError {
+                    code: ErrorCode::NeedsElevation,
+                    message: e.to_string(),
+                }
+            } else {
+                ProtocolError {
+                    code: ErrorCode::Internal,
+                    message: e.to_string(),
+                }
+            }
+        })?;
+
+    let local = handle.localdb();
+    let mut resolved_names = Vec::with_capacity(packages.len());
+
+    for name in packages {
+        // First check if already installed via local DB
+        if let Ok(pkg) = local.pkg(name.as_str()) {
+            // Already installed at a version that satisfies NEEDED flag —
+            // ALPM will skip it during trans_prepare. We still note its name.
+            resolved_names.push(pkg.name().to_string());
+            continue;
+        }
+
+        // Look up in sync DBs
+        let pkg = handle
+            .syncdbs()
+            .find_satisfier(name.as_str())
+            .ok_or_else(|| ProtocolError {
+                code: ErrorCode::PackageNotFound,
+                message: format!("package not found: {name}"),
+            })?;
+
+        resolved_names.push(pkg.name().to_string());
+        handle.trans_add_pkg(pkg).map_err(|e| ProtocolError {
+            code: ErrorCode::DependencyConflict,
+            message: e.to_string(),
+        })?;
+    }
+
+    handle.trans_prepare().map_err(|e| ProtocolError {
+        code: ErrorCode::DependencyConflict,
+        message: e.to_string(),
+    })?;
+
+    let local = handle.localdb();
+    let actions: Vec<PlannedAction> = handle
+        .trans_add()
+        .iter()
+        .map(|pkg| {
+            let old_version = local.pkg(pkg.name()).ok().map(|p| p.version().to_string());
+            let action = match &old_version {
+                None => ActionKind::Install,
+                Some(old) => {
+                    // Compare versions to determine upgrade vs downgrade
+                    use std::cmp::Ordering;
+                    let cmp = alpm::vercmp(old.as_str(), pkg.version().as_str());
+                    match cmp {
+                        Ordering::Less => ActionKind::Upgrade,
+                        Ordering::Greater => ActionKind::Downgrade,
+                        Ordering::Equal => ActionKind::Reinstall,
+                    }
+                }
+            };
+            PlannedAction {
+                name: pkg.name().to_string(),
+                version: pkg.version().to_string(),
+                old_version,
+                action,
+                download_size: pkg.size().max(0) as u64,
+                install_size: pkg.isize().max(0) as u64,
+            }
+        })
+        .collect();
+
+    let total_download: u64 = actions.iter().map(|a| a.download_size).sum();
+    let total_install: u64 = actions.iter().map(|a| a.install_size).sum();
+
+    let _ = handle.trans_release();
+
+    Ok((
+        ResultPayload::InstallPlan {
+            actions,
+            total_download,
+            total_install,
+        },
+        resolved_names,
+    ))
+}
+
+// ── commit (install or remove) ────────────────────────────────────────────
+
+/// Run an install or remove transaction, streaming progress events to koca.
+///
+/// The ALPM handle is created on a dedicated OS thread (Alpm is `!Send`).
+/// Callbacks post events into a `tokio::sync::mpsc` channel which the async
+/// task drains and forwards over the socket.
+pub async fn commit_transaction(
+    msg_id: u64,
+    packages: Vec<String>,
+    is_remove: bool,
+    session: &mut BackendSession,
+) {
+    let (event_tx, mut event_rx) = mpsc::unbounded_channel::<ProtoEvent>();
+
+    let pkgs = packages.clone();
+    let tx_for_thread = event_tx.clone();
+
+    let join_handle = std::thread::spawn(move || -> Result<Vec<String>, ProtocolError> {
+        let mut handle = open_handle().map_err(|e| ProtocolError {
+            code: ErrorCode::Internal,
+            message: e,
+        })?;
+
+        // ── download callback ──────────────────────────────────────────────
+        let dl_tx = tx_for_thread.clone();
+        handle.set_dl_cb(dl_tx, |filename, dl_event: AnyDownloadEvent, tx| {
+            let evt = match dl_event.event() {
+                DownloadEvent::Init(_) => Some(ProtoEvent::Download {
+                    inner: ProtoDownloadEvent::Progress {
+                        package: strip_pkg_ext(filename),
+                        bytes_done: 0,
+                        bytes_total: 0,
+                    },
+                }),
+                DownloadEvent::Progress(p) => Some(ProtoEvent::Download {
+                    inner: ProtoDownloadEvent::Progress {
+                        package: strip_pkg_ext(filename),
+                        bytes_done: p.downloaded.max(0) as u64,
+                        bytes_total: p.total.max(0) as u64,
+                    },
+                }),
+                DownloadEvent::Completed(c) => {
+                    if c.result != DownloadResult::Failed {
+                        Some(ProtoEvent::Download {
+                            inner: ProtoDownloadEvent::ItemDone {
+                                package: strip_pkg_ext(filename),
+                            },
+                        })
+                    } else {
+                        None
+                    }
+                }
+                DownloadEvent::Retry(_) => None,
+            };
+            if let Some(e) = evt {
+                let _ = tx.send(e);
+            }
+        });
+
+        // ── event callback ─────────────────────────────────────────────────
+        let ev_tx = tx_for_thread.clone();
+        let n_pkgs = pkgs.len() as u32;
+        handle.set_event_cb(ev_tx, move |any_event: AnyEvent, tx| {
+            let proto_evt = match any_event.event() {
+                Event::RetrieveStart => Some(ProtoEvent::Download {
+                    inner: ProtoDownloadEvent::Start {
+                        total_bytes: 0,
+                        total_packages: n_pkgs,
+                    },
+                }),
+                Event::RetrieveDone | Event::PkgRetrieveDone(_) => Some(ProtoEvent::Download {
+                    inner: ProtoDownloadEvent::Done,
+                }),
+                Event::TransactionStart => Some(if is_remove {
+                    ProtoEvent::Remove {
+                        inner: ProtoRemoveEvent::Start {
+                            total_packages: n_pkgs,
+                        },
+                    }
+                } else {
+                    ProtoEvent::Install {
+                        inner: ProtoInstallEvent::Start {
+                            total_packages: n_pkgs,
+                        },
+                    }
+                }),
+                Event::TransactionDone => Some(if is_remove {
+                    ProtoEvent::Remove {
+                        inner: ProtoRemoveEvent::Done,
+                    }
+                } else {
+                    ProtoEvent::Install {
+                        inner: ProtoInstallEvent::Done,
+                    }
+                }),
+                Event::HookRunStart(h) => Some(if is_remove {
+                    ProtoEvent::Remove {
+                        inner: ProtoRemoveEvent::Done, // hooks run after remove; reuse Done
+                    }
+                } else {
+                    ProtoEvent::Install {
+                        inner: ProtoInstallEvent::Hook {
+                            name: h.name().to_string(),
+                            current: h.position() as u32,
+                            total: h.total() as u32,
+                        },
+                    }
+                }),
+                _ => None,
+            };
+            if let Some(e) = proto_evt {
+                let _ = tx.send(e);
+            }
+        });
+
+        // ── progress callback ──────────────────────────────────────────────
+        let prog_tx = tx_for_thread.clone();
+        handle.set_progress_cb(
+            prog_tx,
+            move |progress: Progress,
+                  pkgname: &str,
+                  percent: i32,
+                  howmany: usize,
+                  current: usize,
+                  tx| {
+                let action_str = match progress {
+                    Progress::AddStart => "installing",
+                    Progress::UpgradeStart => "upgrading",
+                    Progress::DowngradeStart => "downgrading",
+                    Progress::ReinstallStart => "reinstalling",
+                    Progress::RemoveStart => "removing",
+                    _ => "processing",
+                };
+                let evt = if is_remove {
+                    ProtoEvent::Remove {
+                        inner: ProtoRemoveEvent::Action {
+                            package: pkgname.to_string(),
+                            action: action_str.to_string(),
+                            current: current as u32,
+                            total: howmany as u32,
+                            percent: Some(percent.max(0) as u32),
+                        },
+                    }
+                } else {
+                    ProtoEvent::Install {
+                        inner: ProtoInstallEvent::Action {
+                            package: pkgname.to_string(),
+                            action: action_str.to_string(),
+                            current: current as u32,
+                            total: howmany as u32,
+                            percent: Some(percent.max(0) as u32),
+                        },
+                    }
+                };
+                let _ = tx.send(evt);
+            },
+        );
+
+        // ── transaction ────────────────────────────────────────────────────
+        handle
+            .trans_init(TransFlag::NEEDED)
+            .map_err(|e| ProtocolError {
+                code: if is_permission_error(&e) {
+                    ErrorCode::NeedsElevation
+                } else {
+                    ErrorCode::Internal
+                },
+                message: e.to_string(),
+            })?;
+
+        if is_remove {
+            let local = handle.localdb();
+            for name in &pkgs {
+                match local.pkg(name.as_str()) {
+                    Ok(pkg) => handle.trans_remove_pkg(pkg).map_err(|e| ProtocolError {
+                        code: ErrorCode::DependencyConflict,
+                        message: e.to_string(),
+                    })?,
+                    Err(_) => {
+                        // Package not installed; skip silently
+                    }
+                }
+            }
+        } else {
+            for name in &pkgs {
+                let pkg = handle
+                    .syncdbs()
+                    .find_satisfier(name.as_str())
+                    .ok_or_else(|| ProtocolError {
+                        code: ErrorCode::PackageNotFound,
+                        message: format!("package not found: {name}"),
+                    })?;
+                handle.trans_add_pkg(pkg).map_err(|e| ProtocolError {
+                    code: ErrorCode::DependencyConflict,
+                    message: e.to_string(),
+                })?;
+            }
+        }
+
+        handle.trans_prepare().map_err(|e| ProtocolError {
+            code: ErrorCode::DependencyConflict,
+            message: e.to_string(),
+        })?;
+
+        handle.trans_commit().map_err(|e| ProtocolError {
+            code: ErrorCode::TransactionFailed,
+            message: e.to_string(),
+        })?;
+
+        // Mark newly installed packages as auto (dependency reason)
+        if !is_remove {
+            let local = handle.localdb();
+            for name in &pkgs {
+                if let Ok(pkg) = local.pkg(name.as_str()) {
+                    let _ = pkg.set_reason(PackageReason::Depend);
+                }
+            }
+        }
+
+        // Dropping handle closes the alpm handle, dropping tx_for_thread closes the channel
+        drop(handle);
+        drop(tx_for_thread);
+
+        Ok(pkgs)
+    });
+
+    // Drop our own clone so the channel closes when the thread's clones are dropped
+    drop(event_tx);
+
+    // Stream events to koca as they arrive
+    while let Some(evt) = event_rx.recv().await {
+        let _ = session
+            .send(&Message {
+                id: msg_id,
+                body: MessageBody::Event { event: evt },
+            })
+            .await;
+    }
+
+    // Thread is done — retrieve result and send final message
+    let body = match join_handle.join() {
+        Ok(Ok(names)) => MessageBody::Result {
+            result: if is_remove {
+                ResultPayload::Remove {
+                    success: true,
+                    removed: names,
+                }
+            } else {
+                ResultPayload::Install {
+                    success: true,
+                    installed: names,
+                }
+            },
+        },
+        Ok(Err(e)) => MessageBody::Error { error: e },
+        Err(_) => MessageBody::Error {
+            error: ProtocolError {
+                code: ErrorCode::Internal,
+                message: "backend thread panicked".into(),
+            },
+        },
+    };
+
+    let _ = session.send(&Message { id: msg_id, body }).await;
+}
+
+/// Strip the `.pkg.tar.zst` (and similar) extension from a downloaded filename.
+fn strip_pkg_ext(filename: &str) -> String {
+    // Remove trailing compression extension, then .pkg.tar
+    let s = filename
+        .strip_suffix(".zst")
+        .or_else(|| filename.strip_suffix(".xz"))
+        .or_else(|| filename.strip_suffix(".gz"))
+        .unwrap_or(filename);
+    let s = s.strip_suffix(".pkg.tar").unwrap_or(s);
+    s.to_string()
+}

--- a/crates/backends/alpm/src/handler.rs
+++ b/crates/backends/alpm/src/handler.rs
@@ -15,9 +15,14 @@ fn open_handle() -> Result<Alpm, String> {
     alpm_utils::alpm_with_conf(&conf).map_err(|e| e.to_string())
 }
 
+/// Returns `true` if the ALPM error indicates the database/handle is locked.
+fn is_lock_error(e: &AlpmError) -> bool {
+    matches!(e, AlpmError::HandleLock)
+}
+
 /// Returns `true` if the ALPM error indicates a permission problem.
 fn is_permission_error(e: &AlpmError) -> bool {
-    matches!(e, AlpmError::HandleLock | AlpmError::DbOpen)
+    matches!(e, AlpmError::DbOpen)
         || e.to_string().to_lowercase().contains("permission")
         || e.to_string().to_lowercase().contains("access")
 }
@@ -68,16 +73,16 @@ pub fn install_plan(packages: &[String]) -> Result<(ResultPayload, Vec<String>),
     handle
         .trans_init(TransFlag::NEEDED | TransFlag::NO_LOCK)
         .map_err(|e| {
-            if is_permission_error(&e) {
-                ProtocolError {
-                    code: ErrorCode::NeedsElevation,
-                    message: e.to_string(),
-                }
+            let code = if is_lock_error(&e) {
+                ErrorCode::DatabaseLocked
+            } else if is_permission_error(&e) {
+                ErrorCode::NeedsElevation
             } else {
-                ProtocolError {
-                    code: ErrorCode::Internal,
-                    message: e.to_string(),
-                }
+                ErrorCode::Internal
+            };
+            ProtocolError {
+                code,
+                message: e.to_string(),
             }
         })?;
 
@@ -230,9 +235,10 @@ pub async fn commit_transaction(
                         total_packages: n_pkgs,
                     },
                 }),
-                Event::RetrieveDone | Event::PkgRetrieveDone(_) => Some(ProtoEvent::Download {
+                Event::RetrieveDone => Some(ProtoEvent::Download {
                     inner: ProtoDownloadEvent::Done,
                 }),
+                Event::PkgRetrieveDone(_) => None,
                 Event::TransactionStart => Some(if is_remove {
                     ProtoEvent::Remove {
                         inner: ProtoRemoveEvent::Start {
@@ -255,19 +261,19 @@ pub async fn commit_transaction(
                         inner: ProtoInstallEvent::Done,
                     }
                 }),
-                Event::HookRunStart(h) => Some(if is_remove {
-                    ProtoEvent::Remove {
-                        inner: ProtoRemoveEvent::Done, // hooks run after remove; reuse Done
+                Event::HookRunStart(h) => {
+                    if is_remove {
+                        None
+                    } else {
+                        Some(ProtoEvent::Install {
+                            inner: ProtoInstallEvent::Hook {
+                                name: h.name().to_string(),
+                                current: h.position() as u32,
+                                total: h.total() as u32,
+                            },
+                        })
                     }
-                } else {
-                    ProtoEvent::Install {
-                        inner: ProtoInstallEvent::Hook {
-                            name: h.name().to_string(),
-                            current: h.position() as u32,
-                            total: h.total() as u32,
-                        },
-                    }
-                }),
+                }
                 _ => None,
             };
             if let Some(e) = proto_evt {
@@ -319,16 +325,19 @@ pub async fn commit_transaction(
         );
 
         // ── transaction ────────────────────────────────────────────────────
-        handle
-            .trans_init(TransFlag::NEEDED)
-            .map_err(|e| ProtocolError {
-                code: if is_permission_error(&e) {
-                    ErrorCode::NeedsElevation
-                } else {
-                    ErrorCode::Internal
-                },
+        handle.trans_init(TransFlag::NEEDED).map_err(|e| {
+            let code = if is_lock_error(&e) {
+                ErrorCode::DatabaseLocked
+            } else if is_permission_error(&e) {
+                ErrorCode::NeedsElevation
+            } else {
+                ErrorCode::Internal
+            };
+            ProtocolError {
+                code,
                 message: e.to_string(),
-            })?;
+            }
+        })?;
 
         if is_remove {
             let local = handle.localdb();

--- a/crates/backends/alpm/src/main.rs
+++ b/crates/backends/alpm/src/main.rs
@@ -1,0 +1,90 @@
+use anyhow::Result;
+use clap::Parser;
+use koca_proto::{
+    BackendArgs, BackendSession, Command, ErrorCode, Message, MessageBody, ProtocolError,
+    ResultPayload,
+};
+
+mod handler;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    let args = BackendArgs::parse();
+    let mut session = BackendSession::connect(&args.socket).await?;
+
+    // Package names from the most recent `install-plan`, waiting for confirm/abort.
+    let mut pending: Option<Vec<String>> = None;
+
+    loop {
+        let req = session.recv().await?;
+        let id = req.id;
+
+        match req.cmd {
+            Command::CheckInstalled { packages } => {
+                let body = match handler::check_installed(&packages) {
+                    Ok(result) => MessageBody::Result { result },
+                    Err(e) => MessageBody::Error { error: e },
+                };
+                session.send(&Message { id, body }).await?;
+            }
+
+            Command::InstallPlan { packages } => match handler::install_plan(&packages) {
+                Ok((result, pkg_names)) => {
+                    pending = Some(pkg_names);
+                    session
+                        .send(&Message {
+                            id,
+                            body: MessageBody::Result { result },
+                        })
+                        .await?;
+                }
+                Err(e) => {
+                    session
+                        .send(&Message {
+                            id,
+                            body: MessageBody::Error { error: e },
+                        })
+                        .await?;
+                }
+            },
+
+            Command::Confirm => {
+                if let Some(pkgs) = pending.take() {
+                    handler::commit_transaction(id, pkgs, false, &mut session).await;
+                } else {
+                    session
+                        .send(&Message {
+                            id,
+                            body: MessageBody::Error {
+                                error: ProtocolError {
+                                    code: ErrorCode::Internal,
+                                    message: "no pending transaction to confirm".into(),
+                                },
+                            },
+                        })
+                        .await?;
+                }
+            }
+
+            Command::Abort => {
+                pending = None;
+                session
+                    .send(&Message {
+                        id,
+                        body: MessageBody::Result {
+                            result: ResultPayload::Aborted,
+                        },
+                    })
+                    .await?;
+            }
+
+            Command::Remove { packages } => {
+                handler::commit_transaction(id, packages, true, &mut session).await;
+            }
+
+            Command::Shutdown => break,
+        }
+    }
+
+    Ok(())
+}

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -17,8 +17,11 @@ clap = { workspace = true }
 directories = { workspace = true }
 flate2 = { workspace = true }
 koca = { workspace = true }
+koca-proto = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
+crossterm = { workspace = true }
+ratatui = { workspace = true }
 tar = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -1,4 +1,5 @@
 use clap::{Parser, Subcommand, ValueEnum};
+use koca::BundleFormat;
 use std::path::PathBuf;
 
 #[derive(Clone, ValueEnum)]
@@ -11,6 +12,24 @@ pub enum OutputType {
     All,
 }
 
+impl OutputType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Deb => "deb",
+            Self::Rpm => "rpm",
+            Self::All => "all",
+        }
+    }
+
+    pub fn bundle_formats(&self) -> Vec<BundleFormat> {
+        match self {
+            Self::Deb => vec![BundleFormat::Deb],
+            Self::Rpm => vec![BundleFormat::Rpm],
+            Self::All => vec![BundleFormat::Deb, BundleFormat::Rpm],
+        }
+    }
+}
+
 #[derive(Parser)]
 pub struct CreateArgs {
     /// The path to the build file.
@@ -18,6 +37,15 @@ pub struct CreateArgs {
     /// The output file type.
     #[arg(long, value_enum, default_value_t = OutputType::All)]
     pub output_type: OutputType,
+    /// Override distro detection (e.g. "arch", "debian:12").
+    #[arg(long)]
+    pub target: Option<String>,
+    /// Remove makedepends after a successful build.
+    #[arg(long)]
+    pub rm_deps: bool,
+    /// Skip interactive confirmation prompts.
+    #[arg(long)]
+    pub noconfirm: bool,
 }
 
 #[derive(Parser)]

--- a/crates/cli/src/create.rs
+++ b/crates/cli/src/create.rs
@@ -65,7 +65,7 @@ async fn run_inner(args: &CreateArgs, ui: &mut dyn CreateUi) -> CliMultiResult<(
 
     let mut newly_installed: Vec<String> = Vec::new();
     let total_download_bytes: u64;
-    let mut installed_count: u32 = 0;
+    let installed_count: u32;
 
     if !makedepends.is_empty() || !depends.is_empty() {
         let resolved_makedeps = if makedepends.is_empty() {
@@ -88,6 +88,14 @@ async fn run_inner(args: &CreateArgs, ui: &mut dyn CreateUi) -> CliMultiResult<(
         let makedep_natives = native_names(&resolved_makedeps);
 
         if !makedep_natives.is_empty() {
+            // Build a map from native package name → original constraint for
+            // version satisfaction checks.
+            let native_to_constraint: std::collections::HashMap<&str, &koca::dep::DepConstraint> =
+                resolved_makedeps
+                    .iter()
+                    .flat_map(|r| r.native_names.iter().map(|n| (n.as_str(), &r.constraint)))
+                    .collect();
+
             let mut check_backend = Backend::spawn(backend_bin, false).await.map_err(ke)?;
 
             let check_result = check_backend
@@ -104,7 +112,18 @@ async fn run_inner(args: &CreateArgs, ui: &mut dyn CreateUi) -> CliMultiResult<(
 
             let missing: Vec<String> = statuses
                 .iter()
-                .filter(|s| s.status == InstalledStatus::Missing)
+                .filter(|s| {
+                    if s.status == InstalledStatus::Missing {
+                        return true;
+                    }
+                    // Installed — check if the version satisfies the constraint.
+                    if let (Some(ver), Some(constraint)) =
+                        (&s.version, native_to_constraint.get(s.name.as_str()))
+                    {
+                        return !constraint.satisfied_by(ver);
+                    }
+                    false
+                })
                 .map(|s| s.name.clone())
                 .collect();
 
@@ -158,10 +177,10 @@ async fn run_inner(args: &CreateArgs, ui: &mut dyn CreateUi) -> CliMultiResult<(
 
                 if let ResultPayload::Install { installed, .. } = &result {
                     newly_installed = installed.clone();
-                    installed_count = installed.len() as u32;
                 }
 
                 total_download_bytes = plan_download;
+                installed_count = actions.len() as u32;
                 ui.finish_install(total_download_bytes, installed_count)?;
 
                 sudo_backend.shutdown().await.map_err(ke)?;

--- a/crates/cli/src/create.rs
+++ b/crates/cli/src/create.rs
@@ -1,44 +1,213 @@
-use koca::BuildFile;
-use std::process::Command;
+use koca::{
+    backend::Backend,
+    distro::Distro,
+    resolve::{native_names, resolve_deps},
+    BuildFile,
+};
+use koca_proto::{Command, InstalledStatus, ResultPayload};
+use std::{io, str::FromStr};
+use tokio::io::{AsyncBufReadExt, BufReader};
 
 use crate::{
-    cli::{CreateArgs, OutputType},
+    cli::CreateArgs,
     error::{CliError, CliMultiError, CliMultiResult},
+    tui::{CreateUi, KocaCreateCli, KocaCreateTui},
 };
-use zolt::Colorize;
 
-pub async fn run(create_args: CreateArgs) -> CliMultiResult<()> {
-    let mut build_file = match BuildFile::parse_file(&create_args.build_file).await {
-        Ok(file) => file,
-        Err(errs) => {
-            return Err(CliMultiError(
-                errs.into_iter().map(|err| CliError::Koca { err }).collect(),
-            ))
+fn ke(e: koca::KocaError) -> CliMultiError {
+    CliMultiError::from(CliError::Koca { err: e })
+}
+
+fn spawn_line_reader(
+    reader: impl tokio::io::AsyncRead + Unpin + Send + 'static,
+    tx: tokio::sync::mpsc::UnboundedSender<String>,
+) {
+    let mut lines = BufReader::new(reader).lines();
+    tokio::spawn(async move {
+        while let Ok(Some(line)) = lines.next_line().await {
+            let _ = tx.send(line);
         }
+    });
+}
+
+pub async fn run(args: CreateArgs) -> CliMultiResult<()> {
+    let mut ui: Box<dyn CreateUi> = if std::io::IsTerminal::is_terminal(&io::stdout()) {
+        Box::new(KocaCreateTui::new()?)
+    } else {
+        Box::new(KocaCreateCli::new())
     };
 
-    // Run `build`.
-    zolt::infoln!("Running {} stage...", koca::funcs::BUILD.bold().blue());
-    if let Err(err) = build_file.run_build().await {
+    let result = run_inner(&args, ui.as_mut()).await;
+
+    ui.cleanup();
+
+    result
+}
+
+async fn run_inner(args: &CreateArgs, ui: &mut dyn CreateUi) -> CliMultiResult<()> {
+    let mut build_file = BuildFile::parse_file(&args.build_file)
+        .await
+        .map_err(|errs| {
+            CliMultiError(errs.into_iter().map(|err| CliError::Koca { err }).collect())
+        })?;
+
+    let depends = build_file.depends().to_vec();
+    let makedepends = build_file.makedepends().to_vec();
+
+    let distro = if let Some(target) = &args.target {
+        Distro::from_str(target).map_err(ke)?
+    } else {
+        Distro::detect().map_err(ke)?
+    };
+
+    let repo = distro.repology_repo();
+    let backend_bin = distro.backend_binary();
+
+    let mut newly_installed: Vec<String> = Vec::new();
+    let total_download_bytes: u64;
+    let mut installed_count: u32 = 0;
+
+    if !makedepends.is_empty() || !depends.is_empty() {
+        let resolved_makedeps = if makedepends.is_empty() {
+            vec![]
+        } else {
+            ui.start_resolve()?;
+
+            let mut ticker = tokio::time::interval(std::time::Duration::from_millis(80));
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+            let mut resolve_fut = std::pin::pin!(resolve_deps(&makedepends, &repo));
+            loop {
+                tokio::select! {
+                    result = &mut resolve_fut => break result.map_err(ke)?,
+                    _ = ticker.tick() => { ui.tick()?; }
+                }
+            }
+        };
+
+        let makedep_natives = native_names(&resolved_makedeps);
+
+        if !makedep_natives.is_empty() {
+            let mut check_backend = Backend::spawn(backend_bin, false).await.map_err(ke)?;
+
+            let check_result = check_backend
+                .call(Command::CheckInstalled {
+                    packages: makedep_natives.clone(),
+                })
+                .await
+                .map_err(ke)?;
+
+            let statuses = match check_result {
+                ResultPayload::CheckInstalled { packages } => packages,
+                _ => unreachable!(),
+            };
+
+            let missing: Vec<String> = statuses
+                .iter()
+                .filter(|s| s.status == InstalledStatus::Missing)
+                .map(|s| s.name.clone())
+                .collect();
+
+            if !missing.is_empty() {
+                let plan_result = check_backend
+                    .call(Command::InstallPlan {
+                        packages: missing.clone(),
+                    })
+                    .await
+                    .map_err(ke)?;
+
+                let (actions, plan_download) = match plan_result {
+                    ResultPayload::InstallPlan {
+                        actions,
+                        total_download,
+                        ..
+                    } => (actions, total_download),
+                    _ => unreachable!(),
+                };
+
+                check_backend.shutdown().await.map_err(ke)?;
+
+                let confirmed = ui.show_confirm(&actions, &depends, args.noconfirm)?;
+
+                if !confirmed {
+                    return Ok(());
+                }
+
+                ui.suspend()?;
+                let mut sudo_backend = Backend::spawn(backend_bin, true).await.map_err(ke)?;
+                ui.resume()?;
+
+                sudo_backend
+                    .call(Command::InstallPlan {
+                        packages: missing.clone(),
+                    })
+                    .await
+                    .map_err(ke)?;
+
+                let result = sudo_backend
+                    .call_streaming(Command::Confirm, |event| match event {
+                        None => {
+                            ui.tick().ok();
+                        }
+                        Some(ev) => {
+                            ui.on_event(ev).ok();
+                        }
+                    })
+                    .await
+                    .map_err(ke)?;
+
+                if let ResultPayload::Install { installed, .. } = &result {
+                    newly_installed = installed.clone();
+                    installed_count = installed.len() as u32;
+                }
+
+                total_download_bytes = plan_download;
+                ui.finish_install(total_download_bytes, installed_count)?;
+
+                sudo_backend.shutdown().await.map_err(ke)?;
+            } else {
+                check_backend.shutdown().await.map_err(ke)?;
+            }
+        }
+    }
+
+    ui.start_build()?;
+
+    let build_result = build_file
+        .run_build_with_output(|line| match line {
+            Some(line) => {
+                ui.on_build_line(&line.line).ok();
+            }
+            None => {
+                ui.tick().ok();
+            }
+        })
+        .await;
+
+    if let Err(err) = build_result {
+        ui.show_failure("build")?;
         return Err(CliError::Koca { err }.into());
     }
 
-    // Delegate `package` + `bundle` to a fakeroot subprocess.
-    let output_type_str = match create_args.output_type {
-        OutputType::Deb => "deb",
-        OutputType::Rpm => "rpm",
-        OutputType::All => "all",
-    };
+    let pkgname = build_file.pkgname().to_string();
+    let version = build_file.version().to_string();
+    ui.finish_build(&pkgname, &version)?;
+
+    let output_type_str = args.output_type.as_str();
+
+    ui.start_package()?;
 
     let exe = std::env::current_exe().map_err(|err| CliError::Io { err })?;
-    let status = Command::new("fakeroot")
-        .arg(exe)
+    let mut child = tokio::process::Command::new("fakeroot")
+        .arg(&exe)
         .arg("internal")
         .arg("package")
-        .arg(&create_args.build_file)
+        .arg(&args.build_file)
         .arg("--output-type")
         .arg(output_type_str)
-        .status()
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
         .map_err(|err| {
             if err.kind() == std::io::ErrorKind::NotFound {
                 CliError::FakerootNotFound
@@ -47,8 +216,76 @@ pub async fn run(create_args: CreateArgs) -> CliMultiResult<()> {
             }
         })?;
 
+    let stdout = child.stdout.take().unwrap();
+    let stderr = child.stderr.take().unwrap();
+    let mut ticker = tokio::time::interval(std::time::Duration::from_millis(80));
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+    spawn_line_reader(stdout, tx.clone());
+    spawn_line_reader(stderr, tx);
+
+    loop {
+        ticker.tick().await;
+        ui.tick()?;
+
+        let mut done = false;
+        loop {
+            match rx.try_recv() {
+                Ok(line) => {
+                    ui.on_package_line(&line).ok();
+                }
+                Err(tokio::sync::mpsc::error::TryRecvError::Empty) => break,
+                Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
+                    done = true;
+                    break;
+                }
+            }
+        }
+        if done {
+            break;
+        }
+    }
+
+    let status = child.wait().await.map_err(|err| CliError::Io { err })?;
+
     if !status.success() {
+        ui.show_failure("package")?;
         return Err(CliError::PackageFailed.into());
+    }
+
+    let arch = build_file.arch()[0].clone();
+    let output_files: Vec<String> = args
+        .output_type
+        .bundle_formats()
+        .iter()
+        .map(|fmt| format!("./{}", fmt.output_filename(&pkgname, &version, &arch)))
+        .collect();
+
+    ui.finish_package(&output_files.join(", "))?;
+
+    if args.rm_deps && !newly_installed.is_empty() {
+        zolt::infoln!("Removing {} makedepend(s)...", newly_installed.len());
+        let mut rm_backend = Backend::spawn(backend_bin, true).await.map_err(ke)?;
+
+        rm_backend
+            .call_streaming(
+                Command::Remove {
+                    packages: newly_installed,
+                },
+                |event| match event {
+                    None => {
+                        ui.tick().ok();
+                    }
+                    Some(ev) => {
+                        ui.on_event(ev).ok();
+                    }
+                },
+            )
+            .await
+            .map_err(ke)?;
+
+        rm_backend.shutdown().await.map_err(ke)?;
     }
 
     Ok(())

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -35,3 +35,9 @@ impl From<CliError> for CliMultiError {
         Self(vec![value])
     }
 }
+
+impl From<std::io::Error> for CliMultiError {
+    fn from(err: std::io::Error) -> Self {
+        CliError::Io { err }.into()
+    }
+}

--- a/crates/cli/src/internal/package.rs
+++ b/crates/cli/src/internal/package.rs
@@ -1,9 +1,9 @@
 use std::path::Path;
 
-use koca::{BuildFile, BundleFormat};
+use koca::{BuildFile, BuildOutputLine, BuildOutputStream};
 
 use crate::{
-    cli::{OutputType, PackageArgs},
+    cli::PackageArgs,
     error::{CliError, CliMultiError, CliMultiResult},
 };
 use zolt::Colorize;
@@ -20,30 +20,24 @@ pub async fn run(args: PackageArgs) -> CliMultiResult<()> {
 
     // Run `package`.
     zolt::infoln!("Running {} stage...", koca::funcs::PACKAGE.bold().blue());
-    if let Err(err) = build_file.run_package().await {
+    if let Err(err) = build_file
+        .run_package_with_output(|line| {
+            if let Some(line) = line {
+                print_build_output(line);
+            }
+        })
+        .await
+    {
         return Err(CliError::Koca { err }.into());
     }
 
     // Run the bundle stage.
-    let output_targets = match args.output_type {
-        OutputType::Deb => vec![(BundleFormat::Deb, "deb")],
-        OutputType::Rpm => vec![(BundleFormat::Rpm, "rpm")],
-        OutputType::All => vec![(BundleFormat::Deb, "deb"), (BundleFormat::Rpm, "rpm")],
-    };
-
-    for (bundle_format, file_extension) in output_targets {
+    for bundle_format in args.output_type.bundle_formats() {
         let arch = build_file.arch()[0].clone();
-        let arch_str = match bundle_format {
-            BundleFormat::Deb => arch.get_deb_string(),
-            BundleFormat::Rpm => arch.get_rpm_string(),
-        };
-
-        let file_name = format!(
-            "{}_{}_{}.{}",
+        let file_name = bundle_format.output_filename(
             build_file.pkgname(),
-            build_file.version(),
-            arch_str,
-            file_extension
+            &build_file.version().to_string(),
+            &arch,
         );
 
         zolt::infoln!(
@@ -63,4 +57,11 @@ pub async fn run(args: PackageArgs) -> CliMultiResult<()> {
     zolt::infoln!("Package(s) created successfully.");
 
     Ok(())
+}
+
+fn print_build_output(line: BuildOutputLine) {
+    match line.stream {
+        BuildOutputStream::Stdout => println!("{}", line.line),
+        BuildOutputStream::Stderr => eprintln!("{}", line.line),
+    }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -27,6 +27,11 @@ async fn main() {
         Cli::Internal(args) => internal::run(args).await,
     };
 
+    // Safety net: always restore terminal state on exit, even if cleanup was
+    // missed or failed.
+    crossterm::terminal::disable_raw_mode().ok();
+    let _ = crossterm::execute!(std::io::stdout(), crossterm::cursor::Show);
+
     if let Err(errs) = output {
         for err in errs.0 {
             zolt::errln!("{:?}", anyhow::Error::from(err));

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -4,12 +4,22 @@ mod cli;
 mod create;
 mod error;
 mod internal;
+mod tui;
 
 use clap::Parser;
 use cli::Cli;
 
 #[tokio::main]
 async fn main() {
+    // Ctrl+C handler: restore terminal state before exit.
+    // In raw mode SIGINT is suppressed, so we catch it via tokio.
+    tokio::spawn(async {
+        tokio::signal::ctrl_c().await.ok();
+        crossterm::terminal::disable_raw_mode().ok();
+        let _ = crossterm::execute!(std::io::stdout(), crossterm::cursor::Show);
+        std::process::exit(130);
+    });
+
     let cli = Cli::parse();
 
     let output = match cli {

--- a/crates/cli/src/tui/mod.rs
+++ b/crates/cli/src/tui/mod.rs
@@ -1,0 +1,349 @@
+mod render;
+mod ui;
+mod viewport;
+
+use koca::dep::DepConstraint;
+use koca_proto::{ActionKind, DownloadEvent, Event, InstallEvent, PlannedAction, RemoveEvent};
+use std::io::{self, Write};
+
+pub use ui::KocaCreateTui;
+
+// ── Shared state types used by both impls ──
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Phase {
+    Resolve,
+    Confirm,
+    Download,
+    Install,
+    Build,
+    Package,
+    Done,
+    Failed,
+}
+
+/// Tracks download progress from backend events.
+pub struct DownloadState {
+    pub total_bytes: u64,
+    pub done_bytes: u64,
+    pub total_packages: u32,
+    pub done_count: u32,
+    pub active_names: Vec<String>,
+    pub tick: u32,
+    // Also used during install phase
+    pub current_install_pkg: Option<String>,
+    pub install_current: u32,
+    pub install_total: u32,
+}
+
+impl DownloadState {
+    pub fn new() -> Self {
+        Self {
+            total_bytes: 0,
+            done_bytes: 0,
+            total_packages: 0,
+            done_count: 0,
+            active_names: Vec::new(),
+            tick: 0,
+            current_install_pkg: None,
+            install_current: 0,
+            install_total: 0,
+        }
+    }
+}
+
+/// Summary of completed download+install for display in later phases.
+pub struct InstallSummary {
+    pub total_bytes: u64,
+    pub installed_count: u32,
+}
+
+/// Tracks build/package output lines for the scrolling gutter.
+pub struct BuildState {
+    pub lines: Vec<String>,
+}
+
+impl BuildState {
+    pub fn new() -> Self {
+        Self { lines: Vec::new() }
+    }
+
+    pub fn push_line(&mut self, line: String) {
+        self.lines.push(line);
+    }
+}
+
+// ── Trait ──
+
+pub trait CreateUi {
+    /// Show the resolve spinner while dependencies are being resolved.
+    fn start_resolve(&mut self) -> io::Result<()>;
+
+    /// Show the confirmation screen. Returns true if user confirmed.
+    fn show_confirm(
+        &mut self,
+        actions: &[PlannedAction],
+        depends: &[DepConstraint],
+        noconfirm: bool,
+    ) -> io::Result<bool>;
+
+    /// Handle a backend event (download/install progress).
+    fn on_event(&mut self, event: &Event) -> io::Result<()>;
+
+    /// Called periodically (~80ms) during streaming for spinner animation.
+    fn tick(&mut self) -> io::Result<()>;
+
+    /// Mark download+install as done and transition to build phase display.
+    fn finish_install(&mut self, total_bytes: u64, installed_count: u32) -> io::Result<()>;
+
+    /// Transition to build phase.
+    fn start_build(&mut self) -> io::Result<()>;
+
+    /// Feed a line of build output.
+    fn on_build_line(&mut self, line: &str) -> io::Result<()>;
+
+    /// Mark build as successful.
+    fn finish_build(&mut self, pkgname: &str, version: &str) -> io::Result<()>;
+
+    /// Transition to package phase.
+    fn start_package(&mut self) -> io::Result<()>;
+
+    /// Feed a line of package output.
+    fn on_package_line(&mut self, line: &str) -> io::Result<()>;
+
+    /// Mark packaging as successful.
+    fn finish_package(&mut self, output_file: &str) -> io::Result<()>;
+
+    /// Show failure state.
+    fn show_failure(&mut self, phase_name: &str) -> io::Result<()>;
+
+    /// Suspend the TUI for external I/O (e.g. sudo password prompt).
+    fn suspend(&mut self) -> io::Result<()>;
+
+    /// Resume the TUI after a suspend.
+    fn resume(&mut self) -> io::Result<()>;
+
+    /// Clean up terminal state.
+    fn cleanup(&mut self);
+}
+
+// ── Plain CLI fallback ──
+
+pub struct KocaCreateCli;
+
+impl KocaCreateCli {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl CreateUi for KocaCreateCli {
+    fn start_resolve(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn show_confirm(
+        &mut self,
+        actions: &[PlannedAction],
+        _depends: &[DepConstraint],
+        noconfirm: bool,
+    ) -> io::Result<bool> {
+        use zolt::Colorize;
+
+        println!();
+        println!(
+            "{} {}",
+            "Missing makedepends:".bold(),
+            actions
+                .iter()
+                .map(|a| a.name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+                .yellow()
+        );
+        println!();
+
+        for action in actions {
+            let (icon, color) = match action.action {
+                ActionKind::Install => ("+", "green"),
+                ActionKind::Upgrade => ("^", "yellow"),
+                ActionKind::Downgrade => ("v", "yellow"),
+                ActionKind::Reinstall => ("=", "cyan"),
+                ActionKind::Remove => ("-", "red"),
+            };
+            let line = format!("  {} {} {}", icon, action.name, action.version.dimmed());
+            match color {
+                "green" => println!("{}", line.green()),
+                "yellow" => println!("{}", line.yellow()),
+                "cyan" => println!("{}", line.cyan()),
+                _ => println!("{}", line),
+            }
+        }
+
+        println!();
+
+        if noconfirm {
+            return Ok(true);
+        }
+
+        print!("{} ", "Install missing makedepends? [Y/n]".bold());
+        io::stdout().flush()?;
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
+        let input = input.trim().to_lowercase();
+        Ok(input != "n" && input != "no")
+    }
+
+    fn on_event(&mut self, event: &Event) -> io::Result<()> {
+        use zolt::Colorize;
+
+        match event {
+            Event::Download { inner } => match inner {
+                DownloadEvent::Start { total_packages, .. } => {
+                    println!(
+                        "{} {} package(s)...",
+                        "Downloading".bold().blue(),
+                        total_packages
+                    );
+                }
+                DownloadEvent::Progress {
+                    package,
+                    bytes_done,
+                    bytes_total,
+                } => {
+                    if *bytes_total > 0 {
+                        let pct = bytes_done * 100 / bytes_total;
+                        print!("\r  {} {}%  ", package.dimmed(), pct);
+                        io::stdout().flush()?;
+                    }
+                }
+                DownloadEvent::ItemDone { package } => {
+                    println!("\r  {} {:<50}", "Downloaded".green(), package);
+                }
+                DownloadEvent::Done => {
+                    println!("{}", "Download complete.".green());
+                }
+            },
+            Event::Install { inner } => match inner {
+                InstallEvent::Start { total_packages } => {
+                    println!(
+                        "{} {} package(s)...",
+                        "Installing".bold().blue(),
+                        total_packages
+                    );
+                }
+                InstallEvent::Action {
+                    package,
+                    action,
+                    current,
+                    total,
+                    ..
+                } => {
+                    print!(
+                        "\r  [{}/{}] {} {}  ",
+                        current,
+                        total,
+                        action.bold(),
+                        package
+                    );
+                    io::stdout().flush()?;
+                }
+                InstallEvent::ItemDone { package, .. } => {
+                    println!("\r  {} {:<50}", "Installed".green(), package);
+                }
+                InstallEvent::Hook { name, .. } => {
+                    print!("\r  {} {}  ", "Running hook".dimmed(), name.dimmed());
+                    io::stdout().flush()?;
+                }
+                InstallEvent::Done => {
+                    println!();
+                }
+            },
+            Event::Remove { inner } => match inner {
+                RemoveEvent::Start { total_packages } => {
+                    println!(
+                        "{} {} package(s)...",
+                        "Removing".bold().blue(),
+                        total_packages
+                    );
+                }
+                RemoveEvent::Action {
+                    package,
+                    action,
+                    current,
+                    total,
+                    ..
+                } => {
+                    print!(
+                        "\r  [{}/{}] {} {}  ",
+                        current,
+                        total,
+                        action.bold(),
+                        package
+                    );
+                    io::stdout().flush()?;
+                }
+                RemoveEvent::ItemDone { package, .. } => {
+                    println!("\r  {} {:<50}", "Removed".green(), package);
+                }
+                RemoveEvent::Done => {
+                    println!();
+                }
+            },
+        }
+        Ok(())
+    }
+
+    fn tick(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn finish_install(&mut self, _total_bytes: u64, _installed_count: u32) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn start_build(&mut self) -> io::Result<()> {
+        use zolt::Colorize;
+        println!();
+        zolt::infoln!("Running {} stage...", koca::funcs::BUILD.bold().blue());
+        Ok(())
+    }
+
+    fn on_build_line(&mut self, line: &str) -> io::Result<()> {
+        println!("{}", line);
+        Ok(())
+    }
+
+    fn finish_build(&mut self, _pkgname: &str, _version: &str) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn start_package(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn on_package_line(&mut self, line: &str) -> io::Result<()> {
+        println!("{}", line);
+        Ok(())
+    }
+
+    fn finish_package(&mut self, output_file: &str) -> io::Result<()> {
+        use zolt::Colorize;
+        zolt::infoln!("Package created: {}", output_file.bold());
+        Ok(())
+    }
+
+    fn show_failure(&mut self, _phase_name: &str) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn suspend(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn resume(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn cleanup(&mut self) {}
+}

--- a/crates/cli/src/tui/mod.rs
+++ b/crates/cli/src/tui/mod.rs
@@ -4,6 +4,7 @@ mod viewport;
 
 use koca::dep::DepConstraint;
 use koca_proto::{ActionKind, DownloadEvent, Event, InstallEvent, PlannedAction, RemoveEvent};
+use std::collections::HashMap;
 use std::io::{self, Write};
 
 pub use ui::KocaCreateTui;
@@ -34,6 +35,9 @@ pub struct DownloadState {
     pub current_install_pkg: Option<String>,
     pub install_current: u32,
     pub install_total: u32,
+    /// Per-package progress tracking for accurate byte totals.
+    pkg_done: HashMap<String, u64>,
+    pkg_total: HashMap<String, u64>,
 }
 
 impl DownloadState {
@@ -48,7 +52,19 @@ impl DownloadState {
             current_install_pkg: None,
             install_current: 0,
             install_total: 0,
+            pkg_done: HashMap::new(),
+            pkg_total: HashMap::new(),
         }
+    }
+
+    /// Update per-package progress and recompute aggregate totals.
+    pub fn update_progress(&mut self, package: &str, bytes_done: u64, bytes_total: u64) {
+        self.pkg_done.insert(package.to_string(), bytes_done);
+        if bytes_total > 0 {
+            self.pkg_total.insert(package.to_string(), bytes_total);
+        }
+        self.done_bytes = self.pkg_done.values().sum();
+        self.total_bytes = self.total_bytes.max(self.pkg_total.values().sum());
     }
 }
 

--- a/crates/cli/src/tui/render.rs
+++ b/crates/cli/src/tui/render.rs
@@ -1,0 +1,608 @@
+use koca::dep::DepConstraint;
+use koca_proto::{ActionKind, PlannedAction};
+use ratatui::{
+    layout::{Constraint, Layout, Position, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
+    Frame,
+};
+
+pub const SPINNERS: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+pub const BUILD_GUTTER_MAX: usize = 5;
+
+/// All state needed to render a frame.
+pub struct RenderState<'a> {
+    pub phase: super::Phase,
+    pub info: &'a [Line<'static>],
+    pub dl_state: &'a super::DownloadState,
+    pub install_summary: Option<&'a super::InstallSummary>,
+    pub build_state: &'a super::BuildState,
+    pub pkg_state: &'a super::BuildState,
+    pub build_summary: Option<&'a str>,
+    pub pkg_summary: Option<&'a str>,
+    pub tick: usize,
+}
+
+pub fn format_bytes(b: u64) -> String {
+    if b >= 1_000_000 {
+        format!("{:.1} MB", b as f64 / 1_000_000.0)
+    } else if b >= 1_000 {
+        format!("{:.0} KB", b as f64 / 1_000.0)
+    } else {
+        format!("{} B", b)
+    }
+}
+
+/// Build the styled info lines for the confirm screen from real data.
+pub fn confirm_info_lines(
+    actions: &[PlannedAction],
+    depends: &[DepConstraint],
+) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+
+    if !actions.is_empty() {
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!("{}", actions.len()),
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(" Build Dependencies (makedepends):"),
+        ]));
+
+        for action in actions {
+            let (icon, color) = match action.action {
+                ActionKind::Install => ("+", Color::Green),
+                ActionKind::Upgrade => ("^", Color::Yellow),
+                ActionKind::Downgrade => ("v", Color::Yellow),
+                ActionKind::Reinstall => ("=", Color::Cyan),
+                ActionKind::Remove => ("-", Color::Red),
+            };
+
+            let mut spans = vec![
+                Span::styled(format!("  {} ", icon), Style::default().fg(color)),
+                Span::raw(action.name.clone()),
+            ];
+
+            if let Some(old_ver) = &action.old_version {
+                spans.push(Span::raw(" "));
+                spans.push(Span::styled(
+                    old_ver.clone(),
+                    Style::default()
+                        .fg(Color::DarkGray)
+                        .add_modifier(Modifier::CROSSED_OUT),
+                ));
+            }
+
+            spans.push(Span::raw(" "));
+            spans.push(Span::styled(
+                action.version.clone(),
+                Style::default().fg(Color::DarkGray),
+            ));
+
+            lines.push(Line::from(spans));
+        }
+    }
+
+    if !depends.is_empty() {
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!("{}", depends.len()),
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(" Dependencies (depends):"),
+        ]));
+
+        for dep in depends {
+            let mut spans = vec![
+                Span::styled("  = ", Style::default().fg(Color::DarkGray)),
+                Span::raw(dep.name.clone()),
+            ];
+
+            if let Some(ver) = &dep.version {
+                spans.push(Span::raw(" "));
+                spans.push(Span::styled(
+                    ver.clone(),
+                    Style::default().fg(Color::DarkGray),
+                ));
+            }
+
+            lines.push(Line::from(spans));
+        }
+    }
+
+    lines
+}
+
+/// Render the full frame. Returns the number of content lines used.
+pub fn render(frame: &mut Frame, state: &RenderState) -> u16 {
+    let area = frame.area();
+    let mut y = area.y;
+
+    // Render confirm info at the top (if any)
+    let info_height = state.info.len() as u16;
+    if info_height > 0 {
+        frame.render_widget(
+            Paragraph::new(state.info.to_vec()),
+            Rect {
+                x: area.x,
+                y,
+                width: area.width,
+                height: info_height,
+            },
+        );
+        y += info_height;
+    }
+
+    // Only add a gap line if there's content above (info lines).
+    let gap = if y > area.y { 1 } else { 0 };
+
+    match state.phase {
+        super::Phase::Resolve => {
+            let spinner = SPINNERS[state.tick % SPINNERS.len()];
+            frame.render_widget(
+                Paragraph::new(Line::from(vec![
+                    Span::styled(format!("{} ", spinner), Style::default().fg(Color::Blue)),
+                    Span::styled(
+                        "Resolving dependencies...",
+                        Style::default().add_modifier(Modifier::BOLD),
+                    ),
+                ])),
+                Rect {
+                    x: area.x,
+                    y,
+                    width: area.width,
+                    height: 1,
+                },
+            );
+        }
+        super::Phase::Confirm => {
+            y += gap;
+            frame.render_widget(
+                Paragraph::new(Line::from("Continue? [Y/n] ")),
+                Rect {
+                    x: area.x,
+                    y,
+                    width: area.width,
+                    height: 1,
+                },
+            );
+            frame.set_cursor_position(Position { x: 16, y });
+        }
+        super::Phase::Download => {
+            y += gap;
+            render_download(
+                frame,
+                Rect {
+                    x: area.x,
+                    y,
+                    width: area.width,
+                    height: 2,
+                },
+                state.dl_state,
+            );
+        }
+        super::Phase::Install => {
+            y += gap;
+            frame.render_widget(
+                Paragraph::new(Line::from(vec![
+                    Span::raw("Downloaded "),
+                    Span::styled(
+                        format_bytes(state.dl_state.total_bytes),
+                        Style::default().add_modifier(Modifier::BOLD),
+                    ),
+                ])),
+                Rect {
+                    x: area.x,
+                    y,
+                    width: area.width,
+                    height: 1,
+                },
+            );
+            y += 1;
+
+            let spinner = SPINNERS[state.tick % SPINNERS.len()];
+            let install_text = if let Some(pkg) = &state.dl_state.current_install_pkg {
+                format!(
+                    "Installing ({}/{}) {}...",
+                    state.dl_state.install_current, state.dl_state.install_total, pkg
+                )
+            } else {
+                "Installing...".to_string()
+            };
+            frame.render_widget(
+                Paragraph::new(Line::from(vec![
+                    Span::styled(format!("{} ", spinner), Style::default().fg(Color::Blue)),
+                    Span::raw(install_text),
+                ])),
+                Rect {
+                    x: area.x,
+                    y,
+                    width: area.width,
+                    height: 1,
+                },
+            );
+        }
+        super::Phase::Build => {
+            y += gap;
+            if let Some(summary) = state.install_summary {
+                render_install_summary(frame, area.x, &mut y, area.width, summary);
+            }
+            let gh = 1 + BUILD_GUTTER_MAX as u16;
+            render_build_gutter(
+                frame,
+                Rect {
+                    x: area.x,
+                    y,
+                    width: area.width,
+                    height: gh,
+                },
+                "Building...",
+                &state.build_state.lines,
+                state.tick,
+            );
+        }
+        super::Phase::Package => {
+            y += gap;
+            if let Some(summary) = state.install_summary {
+                render_install_summary(frame, area.x, &mut y, area.width, summary);
+            }
+            if let Some(bs) = state.build_summary {
+                frame.render_widget(
+                    Paragraph::new(Line::from(vec![
+                        Span::raw("Built "),
+                        Span::styled(
+                            bs.to_string(),
+                            Style::default().add_modifier(Modifier::BOLD),
+                        ),
+                    ])),
+                    Rect {
+                        x: area.x,
+                        y,
+                        width: area.width,
+                        height: 1,
+                    },
+                );
+                y += 1;
+            }
+            let gh = 1 + BUILD_GUTTER_MAX as u16;
+            render_build_gutter(
+                frame,
+                Rect {
+                    x: area.x,
+                    y,
+                    width: area.width,
+                    height: gh,
+                },
+                "Packaging...",
+                &state.pkg_state.lines,
+                state.tick,
+            );
+        }
+        super::Phase::Done => {
+            y += gap;
+            if let Some(summary) = state.install_summary {
+                render_install_summary(frame, area.x, &mut y, area.width, summary);
+            }
+            let mut result_spans = Vec::new();
+            if let Some(bs) = state.build_summary {
+                result_spans.push(Span::raw("Built "));
+                result_spans.push(Span::styled(
+                    bs.to_string(),
+                    Style::default().add_modifier(Modifier::BOLD),
+                ));
+            }
+            if let Some(ps) = state.pkg_summary {
+                if !result_spans.is_empty() {
+                    result_spans.push(Span::raw(", "));
+                }
+                result_spans.push(Span::raw("Packaged into "));
+                result_spans.push(Span::styled(
+                    ps.to_string(),
+                    Style::default().add_modifier(Modifier::BOLD),
+                ));
+            }
+            if !result_spans.is_empty() {
+                frame.render_widget(
+                    Paragraph::new(Line::from(result_spans)),
+                    Rect {
+                        x: area.x,
+                        y,
+                        width: area.width,
+                        height: 1,
+                    },
+                );
+            }
+        }
+        super::Phase::Failed => {
+            y += gap;
+            if let Some(summary) = state.install_summary {
+                render_install_summary(frame, area.x, &mut y, area.width, summary);
+            }
+            let phase_label =
+                if !state.build_state.lines.is_empty() && state.pkg_state.lines.is_empty() {
+                    "Building..."
+                } else {
+                    "Packaging..."
+                };
+            frame.render_widget(
+                Paragraph::new(Line::from(vec![
+                    Span::styled(
+                        "error: ",
+                        Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(phase_label, Style::default().add_modifier(Modifier::BOLD)),
+                ])),
+                Rect {
+                    x: area.x,
+                    y,
+                    width: area.width,
+                    height: 1,
+                },
+            );
+            y += 1;
+
+            let err_source = if !state.pkg_state.lines.is_empty() {
+                &state.pkg_state.lines
+            } else {
+                &state.build_state.lines
+            };
+            let err_lines: Vec<Line> = err_source
+                .iter()
+                .map(|text| {
+                    let mut spans = vec![Span::styled("  │ ", Style::default().fg(Color::Red))];
+                    spans.extend(styled_output_line(text, false).spans);
+                    Line::from(spans)
+                })
+                .collect();
+            let el = err_lines.len() as u16;
+            frame.render_widget(
+                Paragraph::new(err_lines),
+                Rect {
+                    x: area.x,
+                    y,
+                    width: area.width,
+                    height: el,
+                },
+            );
+        }
+    }
+
+    y - area.y
+}
+
+fn render_install_summary(
+    frame: &mut Frame,
+    x: u16,
+    y: &mut u16,
+    width: u16,
+    summary: &super::InstallSummary,
+) {
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::raw("Downloaded "),
+            Span::styled(
+                format_bytes(summary.total_bytes),
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(", Installed "),
+            Span::styled(
+                format!("{}", summary.installed_count),
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(" packages"),
+        ])),
+        Rect {
+            x,
+            y: *y,
+            width,
+            height: 1,
+        },
+    );
+    *y += 1;
+}
+
+pub fn render_download(frame: &mut Frame, area: Rect, state: &super::DownloadState) {
+    let chunks = Layout::vertical([Constraint::Length(1), Constraint::Length(1)]).split(area);
+
+    let total_bytes = state.total_bytes;
+    let done_bytes = state.done_bytes;
+    let pct = if total_bytes > 0 {
+        done_bytes as f64 / total_bytes as f64
+    } else {
+        0.0
+    };
+    let total_pkgs = state.total_packages;
+    let width = total_pkgs.to_string().len();
+    let prefix = format!(
+        "Downloading {:>width$}/{} packages ",
+        state.done_count, total_pkgs,
+    );
+    let suffix = format!(
+        " {}% ({}/{})",
+        (pct * 100.0) as u32,
+        format_bytes(done_bytes),
+        format_bytes(total_bytes)
+    );
+    let bar_width = 30usize;
+    let filled = (bar_width as f64 * pct) as usize;
+
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::raw(prefix),
+            Span::styled("█".repeat(filled), Style::default().fg(Color::Green)),
+            Span::styled(
+                "░".repeat(bar_width - filled),
+                Style::default().fg(Color::DarkGray),
+            ),
+            Span::raw(suffix),
+        ])),
+        chunks[0],
+    );
+
+    let spinner = SPINNERS[state.tick as usize % SPINNERS.len()];
+    let status = if !state.active_names.is_empty() {
+        Line::from(vec![
+            Span::raw(format!("{} ", spinner)),
+            Span::raw("active: "),
+            Span::styled(
+                state.active_names.join(", "),
+                Style::default().fg(Color::DarkGray),
+            ),
+        ])
+    } else {
+        Line::from("all downloaded")
+    };
+    frame.render_widget(Paragraph::new(status), chunks[1]);
+}
+
+pub fn render_build_gutter(
+    frame: &mut Frame,
+    area: Rect,
+    header: &str,
+    lines: &[String],
+    tick: usize,
+) {
+    let header_area = Rect { height: 1, ..area };
+    let body_area = Rect {
+        y: area.y + 1,
+        height: area.height.saturating_sub(1),
+        ..area
+    };
+
+    let spinner = SPINNERS[tick % SPINNERS.len()];
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled(format!("{} ", spinner), Style::default().fg(Color::Blue)),
+            Span::styled(header, Style::default().add_modifier(Modifier::BOLD)),
+        ])),
+        header_area,
+    );
+
+    let max_visible = body_area.height as usize;
+    let visible = lines;
+    let start = if visible.len() > max_visible {
+        visible.len() - max_visible
+    } else {
+        0
+    };
+    let output: Vec<Line> = visible[start..]
+        .iter()
+        .map(|text| {
+            let mut spans = vec![Span::styled("  │ ", Style::default().fg(Color::DarkGray))];
+            spans.extend(styled_output_line(text, true).spans);
+            Line::from(spans)
+        })
+        .collect();
+    frame.render_widget(Paragraph::new(output), body_area);
+}
+
+/// Style a build/package output line. Detects keywords like "Compiling", "error", etc.
+pub fn styled_output_line(text: &str, dimmed: bool) -> Line<'static> {
+    let fg = if dimmed {
+        Color::DarkGray
+    } else {
+        Color::Reset
+    };
+
+    // Try to detect known keywords at the start of the line (after optional whitespace)
+    let trimmed = text.trim_start();
+
+    let keywords_green = [
+        "Compiling",
+        "Checking",
+        "Linking",
+        "Finished",
+        "Building",
+        "Downloading",
+        "Downloaded",
+        "Packaging",
+        "Resolving",
+        "Updating",
+        "Fresh",
+        "Running",
+    ];
+    let keywords_red = ["error", "Error"];
+
+    for kw in &keywords_red {
+        if trimmed.starts_with(kw) {
+            let idx = text.find(kw).unwrap();
+            let prefix = &text[..idx];
+            let rest = &text[idx + kw.len()..];
+            return Line::from(vec![
+                Span::styled(prefix.to_string(), Style::default().fg(fg)),
+                Span::styled(
+                    kw.to_string(),
+                    Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    rest.to_string(),
+                    Style::default().fg(if dimmed {
+                        Color::DarkGray
+                    } else {
+                        Color::Reset
+                    }),
+                ),
+            ]);
+        }
+    }
+
+    for kw in &keywords_green {
+        if trimmed.starts_with(kw) {
+            let idx = text.find(kw).unwrap();
+            let prefix = &text[..idx];
+            // Pad to align like cargo output
+            let pad = 12usize.saturating_sub(kw.len());
+            let rest = &text[idx + kw.len()..];
+            return Line::from(vec![
+                Span::raw(" ".repeat(pad)),
+                Span::styled(
+                    format!("{}{}", prefix, kw),
+                    Style::default()
+                        .fg(if dimmed {
+                            Color::DarkGray
+                        } else {
+                            Color::Green
+                        })
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(rest.to_string(), Style::default().fg(fg)),
+            ]);
+        }
+    }
+
+    // Fallback: plain text
+    Line::from(Span::styled(text.to_string(), Style::default().fg(fg)))
+}
+
+/// Calculate the viewport height needed for the current state.
+pub fn calc_height(state: &RenderState) -> u16 {
+    let base = state.info.len() as u16;
+    let gap: u16 = if base > 0 { 1 } else { 0 };
+    let summary: u16 = if state.install_summary.is_some() {
+        1
+    } else {
+        0
+    };
+    match state.phase {
+        super::Phase::Resolve => 1,
+        super::Phase::Confirm => base + gap + 1,
+        super::Phase::Download => base + gap + 2,
+        super::Phase::Install => base + gap + 2,
+        super::Phase::Build => base + gap + summary + 1 + BUILD_GUTTER_MAX as u16,
+        super::Phase::Package => {
+            let built = if state.build_summary.is_some() { 1 } else { 0 };
+            base + gap + summary + built + 1 + BUILD_GUTTER_MAX as u16
+        }
+        super::Phase::Done => base + gap + summary + 1,
+        super::Phase::Failed => {
+            let err_lines = if !state.pkg_state.lines.is_empty() {
+                state.pkg_state.lines.len()
+            } else {
+                state.build_state.lines.len()
+            }
+            .min(200) as u16;
+            base + gap + summary + 1 + err_lines
+        }
+    }
+}

--- a/crates/cli/src/tui/render.rs
+++ b/crates/cli/src/tui/render.rs
@@ -94,18 +94,10 @@ pub fn confirm_info_lines(
         ]));
 
         for dep in depends {
-            let mut spans = vec![
+            let spans = vec![
                 Span::styled("  = ", Style::default().fg(Color::DarkGray)),
-                Span::raw(dep.name.clone()),
+                Span::raw(dep.to_string()),
             ];
-
-            if let Some(ver) = &dep.version {
-                spans.push(Span::raw(" "));
-                spans.push(Span::styled(
-                    ver.clone(),
-                    Style::default().fg(Color::DarkGray),
-                ));
-            }
 
             lines.push(Line::from(spans));
         }
@@ -312,6 +304,7 @@ pub fn render(frame: &mut Frame, state: &RenderState) -> u16 {
                         height: 1,
                     },
                 );
+                y += 1;
             }
         }
         super::Phase::Failed => {

--- a/crates/cli/src/tui/ui.rs
+++ b/crates/cli/src/tui/ui.rs
@@ -1,6 +1,8 @@
+use crossterm::event::{self as ct_event, KeyCode, KeyModifiers};
 use koca::dep::DepConstraint;
 use koca_proto::{DownloadEvent, Event, InstallEvent, PlannedAction};
 use std::io::{self, Write};
+use std::time::Duration;
 
 use super::render::{self, confirm_info_lines, RenderState};
 use super::viewport::DynViewport;
@@ -9,6 +11,9 @@ use super::{BuildState, CreateUi, DownloadState, InstallSummary, Phase};
 pub struct KocaCreateTui {
     phase: Phase,
     vp: Option<DynViewport>,
+    /// Use `DynViewport::at_cursor` instead of `::new` for the next viewport
+    /// creation (avoids DSR escape flash after external I/O like sudo).
+    skip_dsr: bool,
     info: Vec<ratatui::text::Line<'static>>,
     dl_state: DownloadState,
     install_summary: Option<InstallSummary>,
@@ -17,8 +22,6 @@ pub struct KocaCreateTui {
     build_summary: Option<String>,
     pkg_summary: Option<String>,
     tick: usize,
-    /// Actual content height from the last render, used for cleanup positioning.
-    content_height: u16,
 }
 
 impl KocaCreateTui {
@@ -26,6 +29,7 @@ impl KocaCreateTui {
         Ok(Self {
             phase: Phase::Resolve,
             vp: None,
+            skip_dsr: false,
             info: Vec::new(),
             dl_state: DownloadState::new(),
             install_summary: None,
@@ -34,7 +38,6 @@ impl KocaCreateTui {
             build_summary: None,
             pkg_summary: None,
             tick: 0,
-            content_height: 0,
         })
     }
 
@@ -60,14 +63,17 @@ impl KocaCreateTui {
         let height = render::calc_height(&state);
 
         if self.vp.is_none() {
-            self.vp = Some(DynViewport::new(height)?);
+            self.vp = Some(if self.skip_dsr {
+                self.skip_dsr = false;
+                DynViewport::at_cursor(height)?
+            } else {
+                DynViewport::new(height)?
+            });
         }
 
-        let content_height = std::cell::Cell::new(0u16);
         self.vp.as_mut().unwrap().draw(height, |f| {
-            content_height.set(render::render(f, &state));
+            render::render(f, &state);
         })?;
-        self.content_height = content_height.get();
         Ok(())
     }
 }
@@ -122,9 +128,10 @@ impl CreateUi for KocaCreateTui {
                 DownloadEvent::Progress {
                     package,
                     bytes_done,
-                    bytes_total: _,
+                    bytes_total,
                 } => {
-                    self.dl_state.done_bytes = self.dl_state.done_bytes.max(*bytes_done);
+                    self.dl_state
+                        .update_progress(package, *bytes_done, *bytes_total);
                     if !self.dl_state.active_names.contains(package) {
                         self.dl_state.active_names.push(package.clone());
                     }
@@ -164,6 +171,15 @@ impl CreateUi for KocaCreateTui {
     }
 
     fn tick(&mut self) -> io::Result<()> {
+        // In raw mode SIGINT is suppressed, so check for Ctrl+C as a key event.
+        if ct_event::poll(Duration::ZERO)? {
+            if let ct_event::Event::Key(key) = ct_event::read()? {
+                if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+                    self.cleanup();
+                    std::process::exit(130);
+                }
+            }
+        }
         self.tick += 1;
         self.dl_state.tick += 1;
         self.redraw()
@@ -229,12 +245,13 @@ impl CreateUi for KocaCreateTui {
         // (sudo, user input) may have moved the cursor. The next redraw()
         // will lazily create a fresh viewport at the current cursor position.
         self.vp = None;
+        self.skip_dsr = true;
         Ok(())
     }
 
     fn cleanup(&mut self) {
         if let Some(mut vp) = self.vp.take() {
-            vp.cleanup_at(self.content_height).ok();
+            vp.cleanup().ok();
         }
     }
 }

--- a/crates/cli/src/tui/ui.rs
+++ b/crates/cli/src/tui/ui.rs
@@ -1,0 +1,240 @@
+use koca::dep::DepConstraint;
+use koca_proto::{DownloadEvent, Event, InstallEvent, PlannedAction};
+use std::io::{self, Write};
+
+use super::render::{self, confirm_info_lines, RenderState};
+use super::viewport::DynViewport;
+use super::{BuildState, CreateUi, DownloadState, InstallSummary, Phase};
+
+pub struct KocaCreateTui {
+    phase: Phase,
+    vp: Option<DynViewport>,
+    info: Vec<ratatui::text::Line<'static>>,
+    dl_state: DownloadState,
+    install_summary: Option<InstallSummary>,
+    build_state: BuildState,
+    pkg_state: BuildState,
+    build_summary: Option<String>,
+    pkg_summary: Option<String>,
+    tick: usize,
+    /// Actual content height from the last render, used for cleanup positioning.
+    content_height: u16,
+}
+
+impl KocaCreateTui {
+    pub fn new() -> io::Result<Self> {
+        Ok(Self {
+            phase: Phase::Resolve,
+            vp: None,
+            info: Vec::new(),
+            dl_state: DownloadState::new(),
+            install_summary: None,
+            build_state: BuildState::new(),
+            pkg_state: BuildState::new(),
+            build_summary: None,
+            pkg_summary: None,
+            tick: 0,
+            content_height: 0,
+        })
+    }
+
+    fn redraw(&mut self) -> io::Result<()> {
+        // After confirm, the viewport is dropped and info cleared. Don't
+        // create a new viewport until a real phase transition happens.
+        if self.vp.is_none() && self.phase == Phase::Confirm {
+            return Ok(());
+        }
+
+        let state = RenderState {
+            phase: self.phase,
+            info: &self.info,
+            dl_state: &self.dl_state,
+            install_summary: self.install_summary.as_ref(),
+            build_state: &self.build_state,
+            pkg_state: &self.pkg_state,
+            build_summary: self.build_summary.as_deref(),
+            pkg_summary: self.pkg_summary.as_deref(),
+            tick: self.tick,
+        };
+
+        let height = render::calc_height(&state);
+
+        if self.vp.is_none() {
+            self.vp = Some(DynViewport::new(height)?);
+        }
+
+        let content_height = std::cell::Cell::new(0u16);
+        self.vp.as_mut().unwrap().draw(height, |f| {
+            content_height.set(render::render(f, &state));
+        })?;
+        self.content_height = content_height.get();
+        Ok(())
+    }
+}
+
+impl CreateUi for KocaCreateTui {
+    fn start_resolve(&mut self) -> io::Result<()> {
+        self.phase = Phase::Resolve;
+        self.redraw()
+    }
+
+    fn show_confirm(
+        &mut self,
+        actions: &[PlannedAction],
+        depends: &[DepConstraint],
+        noconfirm: bool,
+    ) -> io::Result<bool> {
+        self.info = confirm_info_lines(actions, depends);
+        self.phase = Phase::Confirm;
+        self.redraw()?;
+
+        if noconfirm {
+            return Ok(true);
+        }
+
+        // Suspend TUI so stdin echoes and Ctrl+C works for Y/n input.
+        // Keep cursor where ratatui left it (after "Continue? [Y/n] ").
+        self.vp.as_mut().unwrap().suspend(true)?;
+        io::stdout().flush()?;
+
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
+
+        // The confirm info is now visible on the terminal. Clear it from state
+        // so it isn't duplicated when a new viewport is created for later phases.
+        self.info.clear();
+
+        let input = input.trim().to_lowercase();
+        Ok(input != "n" && input != "no")
+    }
+
+    fn on_event(&mut self, event: &Event) -> io::Result<()> {
+        match event {
+            Event::Download { inner } => match inner {
+                DownloadEvent::Start {
+                    total_bytes,
+                    total_packages,
+                } => {
+                    self.phase = Phase::Download;
+                    self.dl_state.total_bytes = *total_bytes;
+                    self.dl_state.total_packages = *total_packages;
+                }
+                DownloadEvent::Progress {
+                    package,
+                    bytes_done,
+                    bytes_total: _,
+                } => {
+                    self.dl_state.done_bytes = self.dl_state.done_bytes.max(*bytes_done);
+                    if !self.dl_state.active_names.contains(package) {
+                        self.dl_state.active_names.push(package.clone());
+                    }
+                }
+                DownloadEvent::ItemDone { package } => {
+                    self.dl_state.done_count += 1;
+                    self.dl_state.active_names.retain(|n| n != package);
+                }
+                DownloadEvent::Done => {
+                    self.dl_state.done_bytes = self.dl_state.total_bytes;
+                    self.dl_state.done_count = self.dl_state.total_packages;
+                    self.dl_state.active_names.clear();
+                }
+            },
+            Event::Install { inner } => match inner {
+                InstallEvent::Start { total_packages } => {
+                    self.phase = Phase::Install;
+                    self.dl_state.install_total = *total_packages;
+                }
+                InstallEvent::Action {
+                    package,
+                    current,
+                    total,
+                    ..
+                } => {
+                    self.dl_state.current_install_pkg = Some(package.clone());
+                    self.dl_state.install_current = *current;
+                    self.dl_state.install_total = *total;
+                }
+                InstallEvent::ItemDone { .. } => {}
+                InstallEvent::Hook { .. } => {}
+                InstallEvent::Done => {}
+            },
+            Event::Remove { .. } => {}
+        }
+        self.redraw()
+    }
+
+    fn tick(&mut self) -> io::Result<()> {
+        self.tick += 1;
+        self.dl_state.tick += 1;
+        self.redraw()
+    }
+
+    fn finish_install(&mut self, total_bytes: u64, installed_count: u32) -> io::Result<()> {
+        self.install_summary = Some(InstallSummary {
+            total_bytes,
+            installed_count,
+        });
+        Ok(())
+    }
+
+    fn start_build(&mut self) -> io::Result<()> {
+        self.phase = Phase::Build;
+        self.build_state = BuildState::new();
+        self.redraw()
+    }
+
+    fn on_build_line(&mut self, line: &str) -> io::Result<()> {
+        self.build_state.push_line(line.to_string());
+        self.tick += 1;
+        self.redraw()
+    }
+
+    fn finish_build(&mut self, pkgname: &str, version: &str) -> io::Result<()> {
+        self.build_summary = Some(format!("{} {}", pkgname, version));
+        Ok(())
+    }
+
+    fn start_package(&mut self) -> io::Result<()> {
+        self.phase = Phase::Package;
+        self.pkg_state = BuildState::new();
+        self.redraw()
+    }
+
+    fn on_package_line(&mut self, line: &str) -> io::Result<()> {
+        self.pkg_state.push_line(line.to_string());
+        self.tick += 1;
+        self.redraw()
+    }
+
+    fn finish_package(&mut self, output_file: &str) -> io::Result<()> {
+        self.pkg_summary = Some(output_file.to_string());
+        self.phase = Phase::Done;
+        self.redraw()
+    }
+
+    fn show_failure(&mut self, _phase_name: &str) -> io::Result<()> {
+        self.phase = Phase::Failed;
+        self.redraw()
+    }
+
+    fn suspend(&mut self) -> io::Result<()> {
+        if let Some(vp) = self.vp.as_mut() {
+            vp.suspend(false)?;
+        }
+        Ok(())
+    }
+
+    fn resume(&mut self) -> io::Result<()> {
+        // Drop the old viewport -- its position is stale after external I/O
+        // (sudo, user input) may have moved the cursor. The next redraw()
+        // will lazily create a fresh viewport at the current cursor position.
+        self.vp = None;
+        Ok(())
+    }
+
+    fn cleanup(&mut self) {
+        if let Some(mut vp) = self.vp.take() {
+            vp.cleanup_at(self.content_height).ok();
+        }
+    }
+}

--- a/crates/cli/src/tui/viewport.rs
+++ b/crates/cli/src/tui/viewport.rs
@@ -59,6 +59,39 @@ impl DynViewport {
         })
     }
 
+    /// Create a viewport at the current cursor position without using
+    /// `Viewport::Inline` (avoids the DSR query that can flash escape chars).
+    pub fn at_cursor(height: u16) -> io::Result<Self> {
+        terminal::enable_raw_mode()?;
+
+        // Drain stale input.
+        while event::poll(Duration::from_millis(0))? {
+            let _ = event::read()?;
+        }
+
+        let (width, term_h) = terminal::size()?;
+        let (_, cursor_y) = cursor::position()?;
+
+        // Scroll the terminal if we're near the bottom.
+        let top_y = if cursor_y + height >= term_h {
+            let scroll = cursor_y + height - term_h + 1;
+            let mut out = io::stdout();
+            execute!(out, terminal::ScrollUp(scroll))?;
+            cursor_y.saturating_sub(scroll)
+        } else {
+            cursor_y
+        };
+
+        let terminal = make_fixed_terminal(top_y, width, height)?;
+
+        Ok(Self {
+            terminal,
+            current_vh: height,
+            top_y,
+            width,
+        })
+    }
+
     /// Draw a frame.  Resizes the viewport first if needed.
     pub fn draw<F>(&mut self, needed: u16, draw_fn: F) -> io::Result<()>
     where
@@ -85,18 +118,21 @@ impl DynViewport {
         Ok(())
     }
 
-    /// Position cursor after `content_height` lines of actual content and
-    /// restore terminal.  Avoids blank lines below the last rendered line.
-    pub fn cleanup_at(&mut self, content_height: u16) -> io::Result<()> {
+    /// Clear the viewport area, position cursor after the content, and
+    /// restore the terminal to normal mode.
+    pub fn cleanup(&mut self) -> io::Result<()> {
         let mut out = io::stdout();
-        execute!(
-            out,
-            cursor::MoveTo(0, self.top_y + content_height),
-            cursor::Show
-        )?;
+        // Best-effort clear — don't let escape sequence failures prevent
+        // disable_raw_mode from running.
+        for row in 0..self.current_vh {
+            let _ = queue!(
+                out,
+                cursor::MoveTo(0, self.top_y + row),
+                terminal::Clear(terminal::ClearType::CurrentLine),
+            );
+        }
+        let _ = execute!(out, cursor::MoveTo(0, self.top_y), cursor::Show);
         terminal::disable_raw_mode()?;
-        // Print a newline so the shell prompt starts below the content.
-        writeln!(out)?;
         Ok(())
     }
 

--- a/crates/cli/src/tui/viewport.rs
+++ b/crates/cli/src/tui/viewport.rs
@@ -1,0 +1,126 @@
+use crossterm::{cursor, event, execute, queue, terminal};
+use ratatui::layout::Rect;
+use ratatui::{Terminal, TerminalOptions, Viewport};
+use std::io::{self, Stdout, Write};
+use std::time::Duration;
+
+type Term = Terminal<ratatui::backend::CrosstermBackend<Stdout>>;
+
+/// Create a terminal with a fixed viewport — no DSR cursor query.
+fn make_fixed_terminal(top_y: u16, width: u16, height: u16) -> io::Result<Term> {
+    Terminal::with_options(
+        ratatui::backend::CrosstermBackend::new(io::stdout()),
+        TerminalOptions {
+            viewport: Viewport::Fixed(Rect::new(0, top_y, width, height)),
+        },
+    )
+}
+
+/// Dynamic viewport manager.
+///
+/// Uses `Viewport::Inline` exactly once (in `new()`) so ratatui handles
+/// scrolling to make room.  Saves the resulting position and uses
+/// `Viewport::Fixed` for all subsequent resizes — no more DSR queries.
+pub struct DynViewport {
+    terminal: Term,
+    current_vh: u16,
+    top_y: u16,
+    width: u16,
+}
+
+impl DynViewport {
+    pub fn new(height: u16) -> io::Result<Self> {
+        terminal::enable_raw_mode()?;
+
+        // Drain stale input so the initial DSR query isn't corrupted.
+        while event::poll(Duration::from_millis(0))? {
+            let _ = event::read()?;
+        }
+
+        // Use Viewport::Inline for the first creation — ratatui queries the
+        // cursor position (one DSR) and scrolls the terminal to make room.
+        let mut terminal = Terminal::with_options(
+            ratatui::backend::CrosstermBackend::new(io::stdout()),
+            TerminalOptions {
+                viewport: Viewport::Inline(height),
+            },
+        )?;
+
+        // Save the position ratatui chose so we can use Fixed from now on.
+        let area = terminal.get_frame().area();
+        let top_y = area.y;
+        let width = area.width;
+
+        Ok(Self {
+            terminal,
+            current_vh: height,
+            top_y,
+            width,
+        })
+    }
+
+    /// Draw a frame.  Resizes the viewport first if needed.
+    pub fn draw<F>(&mut self, needed: u16, draw_fn: F) -> io::Result<()>
+    where
+        F: FnOnce(&mut ratatui::Frame),
+    {
+        if needed != self.current_vh {
+            self.replace_viewport(needed)?;
+        }
+        self.terminal.draw(draw_fn)?;
+        Ok(())
+    }
+
+    /// Temporarily leave the viewport for external I/O (sudo, user input).
+    /// If `at_cursor` is true the cursor stays where ratatui left it;
+    /// otherwise it moves below the viewport.
+    pub fn suspend(&mut self, at_cursor: bool) -> io::Result<()> {
+        if !at_cursor {
+            let mut out = io::stdout();
+            execute!(out, cursor::MoveTo(0, self.top_y + self.current_vh))?;
+        }
+        let mut out = io::stdout();
+        execute!(out, cursor::Show)?;
+        terminal::disable_raw_mode()?;
+        Ok(())
+    }
+
+    /// Position cursor after `content_height` lines of actual content and
+    /// restore terminal.  Avoids blank lines below the last rendered line.
+    pub fn cleanup_at(&mut self, content_height: u16) -> io::Result<()> {
+        let mut out = io::stdout();
+        execute!(
+            out,
+            cursor::MoveTo(0, self.top_y + content_height),
+            cursor::Show
+        )?;
+        terminal::disable_raw_mode()?;
+        // Print a newline so the shell prompt starts below the content.
+        writeln!(out)?;
+        Ok(())
+    }
+
+    fn replace_viewport(&mut self, new_height: u16) -> io::Result<()> {
+        // Clear old viewport lines (batched into a single flush)
+        let mut out = io::stdout();
+        queue!(out, cursor::MoveTo(0, self.top_y))?;
+        for _ in 0..self.current_vh {
+            queue!(
+                out,
+                terminal::Clear(terminal::ClearType::CurrentLine),
+                cursor::MoveDown(1),
+            )?;
+        }
+        queue!(out, cursor::MoveTo(0, self.top_y))?;
+        out.flush()?;
+
+        // Refresh width in case terminal was resized
+        let (width, _) = terminal::size()?;
+        self.width = width;
+
+        // Fixed at the same top_y — no DSR query
+        self.terminal = make_fixed_terminal(self.top_y, width, new_height)?;
+        self.current_vh = new_height;
+        Ok(())
+    }
+}

--- a/crates/koca/Cargo.toml
+++ b/crates/koca/Cargo.toml
@@ -11,10 +11,14 @@ repository.workspace = true
 brush = { workspace = true }
 brush-parser = { workspace = true }
 itertools = "0.14.0"
+koca-proto = { workspace = true }
+libversion = { workspace = true }
 nix = { workspace = true }
+repology = { workspace = true }
 nfpm-sys = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true }
 walkdir = { workspace = true }

--- a/crates/koca/src/backend.rs
+++ b/crates/koca/src/backend.rs
@@ -1,0 +1,118 @@
+use koca_proto::{
+    socket_name,
+    transport::{KocaListener, KocaSession},
+    Command, MessageBody, ProtoError, ResultPayload,
+};
+
+use crate::{KocaError, KocaResult};
+
+/// A running backend process and its associated [`KocaSession`].
+pub struct Backend {
+    pub session: KocaSession,
+    pub child: tokio::process::Child,
+}
+
+impl Backend {
+    /// Spawn a backend binary and wait for it to connect.
+    ///
+    /// Creates a local socket, spawns the binary with `--socket <name>`,
+    /// then accepts the connection.
+    pub async fn spawn(binary: &str, sudo: bool) -> KocaResult<Self> {
+        let name = socket_name();
+
+        // Create listener BEFORE spawning so the socket exists when the child
+        // tries to connect.
+        let listener = KocaListener::listen(&name).map_err(proto_to_koca)?;
+
+        let child = spawn_process(binary, sudo, &name)?;
+
+        let session = listener.accept().await.map_err(proto_to_koca)?;
+
+        Ok(Self { session, child })
+    }
+
+    /// Send a simple request and wait for the result (no streaming events).
+    pub async fn call(&mut self, cmd: Command) -> KocaResult<ResultPayload> {
+        self.session.call(cmd).await.map_err(proto_to_koca)
+    }
+
+    /// Send a streaming command (e.g. `Confirm`) and drive the event loop.
+    ///
+    /// `callback` is called with `None` every ~80ms for spinner animation,
+    /// and with `Some(&event)` for each progress event from the backend.
+    /// Using a single callback avoids the double-borrow problem when the
+    /// caller needs `&mut` access to shared state from both tick and event
+    /// paths.
+    pub async fn call_streaming(
+        &mut self,
+        cmd: Command,
+        mut callback: impl FnMut(Option<&koca_proto::Event>),
+    ) -> KocaResult<ResultPayload> {
+        self.session.send(cmd).await.map_err(proto_to_koca)?;
+
+        let mut ticker = tokio::time::interval(std::time::Duration::from_millis(80));
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        loop {
+            ticker.tick().await;
+            callback(None); // tick
+
+            // Drain all buffered events that arrived during this tick window
+            loop {
+                match self.session.try_recv().map_err(proto_to_koca)? {
+                    None => break,
+                    Some(MessageBody::Event { event }) => callback(Some(&event)),
+                    Some(MessageBody::Result { result }) => return Ok(result),
+                    Some(MessageBody::Error { error }) => {
+                        return Err(KocaError::IO(std::io::Error::other(error.to_string())))
+                    }
+                }
+            }
+        }
+    }
+
+    /// Send `Shutdown` and wait for the backend process to exit cleanly.
+    pub async fn shutdown(mut self) -> KocaResult<()> {
+        self.session.shutdown().await.map_err(proto_to_koca)?;
+        let _ = self.child.wait().await;
+        Ok(())
+    }
+}
+
+/// Resolve a binary name to its absolute path by searching `PATH`.
+fn resolve_binary(binary: &str) -> KocaResult<std::path::PathBuf> {
+    std::env::var_os("PATH")
+        .and_then(|paths| {
+            std::env::split_paths(&paths)
+                .map(|dir| dir.join(binary))
+                .find(|p| p.is_file())
+        })
+        .ok_or_else(|| {
+            KocaError::IO(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("backend binary '{binary}' not found in PATH"),
+            ))
+        })
+}
+
+fn spawn_process(binary: &str, sudo: bool, socket_name: &str) -> KocaResult<tokio::process::Child> {
+    // Resolve to absolute path so sudo (which uses a restricted PATH) can
+    // find the binary.
+    let bin_path = resolve_binary(binary)?;
+
+    let mut cmd = if sudo {
+        let mut c = tokio::process::Command::new("sudo");
+        c.arg(&bin_path);
+        c
+    } else {
+        tokio::process::Command::new(&bin_path)
+    };
+
+    cmd.arg("--socket").arg(socket_name);
+
+    cmd.spawn().map_err(KocaError::IO)
+}
+
+pub fn proto_to_koca(e: ProtoError) -> KocaError {
+    KocaError::IO(std::io::Error::other(e.to_string()))
+}

--- a/crates/koca/src/dep.rs
+++ b/crates/koca/src/dep.rs
@@ -1,0 +1,188 @@
+use std::cmp::Ordering;
+
+use libversion::version_compare2;
+
+use crate::{KocaError, KocaResult};
+
+/// A dependency constraint parsed from a `.koca` file's `depends` or
+/// `makedepends` array.
+///
+/// The `name` is a **repology project name** (e.g. `"openssl"`, `"cmake"`).
+/// Version operators map directly to what pacman/dpkg support.
+///
+/// # Examples
+/// ```text
+/// openssl>=3.0   →  DepConstraint { name: "openssl", op: Some(Ge), version: Some("3.0") }
+/// curl           →  DepConstraint { name: "curl",    op: None,     version: None         }
+/// gcc=14.1.0     →  DepConstraint { name: "gcc",     op: Some(Eq), version: Some("14.1.0") }
+/// python<4       →  DepConstraint { name: "python",  op: Some(Lt), version: Some("4")    }
+/// ```
+#[derive(Debug, Clone)]
+pub struct DepConstraint {
+    /// Repology project name.
+    pub name: String,
+    pub op: Option<DepOp>,
+    pub version: Option<String>,
+}
+
+/// Version comparison operator in a dependency constraint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DepOp {
+    Ge, // >=
+    Le, // <=
+    Gt, // >
+    Lt, // <
+    Eq, // =
+}
+
+impl DepOp {
+    fn as_str(self) -> &'static str {
+        match self {
+            DepOp::Ge => ">=",
+            DepOp::Le => "<=",
+            DepOp::Gt => ">",
+            DepOp::Lt => "<",
+            DepOp::Eq => "=",
+        }
+    }
+}
+
+impl std::fmt::Display for DepConstraint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name)?;
+        if let (Some(op), Some(ver)) = (&self.op, &self.version) {
+            write!(f, "{}{}", op.as_str(), ver)?;
+        }
+        Ok(())
+    }
+}
+
+impl DepConstraint {
+    /// Parse a dependency string like `"openssl>=3.0"` or `"curl"`.
+    ///
+    /// Operators are tried longest-first (`>=` before `>`) to avoid
+    /// mismatching `>=` as `>`.
+    pub fn parse(s: &str) -> KocaResult<Self> {
+        // Try operators longest-first to avoid ">=" being parsed as ">"
+        const OPS: &[(&str, DepOp)] = &[
+            (">=", DepOp::Ge),
+            ("<=", DepOp::Le),
+            (">", DepOp::Gt),
+            ("<", DepOp::Lt),
+            ("=", DepOp::Eq),
+        ];
+
+        for (op_str, op) in OPS {
+            if let Some((name, ver)) = s.split_once(op_str) {
+                let name = name.trim();
+                let ver = ver.trim();
+                if name.is_empty() {
+                    return Err(KocaError::InvalidDep(s.to_string()));
+                }
+                return Ok(Self {
+                    name: name.to_string(),
+                    op: Some(*op),
+                    version: Some(ver.to_string()),
+                });
+            }
+        }
+
+        // No operator found — bare package name
+        let name = s.trim();
+        if name.is_empty() {
+            return Err(KocaError::InvalidDep(s.to_string()));
+        }
+        Ok(Self {
+            name: name.to_string(),
+            op: None,
+            version: None,
+        })
+    }
+
+    /// Check whether `installed_version` satisfies this constraint.
+    ///
+    /// Uses `libversion` (repology's version comparison algorithm) for
+    /// cross-distro-compatible comparisons.
+    ///
+    /// Returns `true` when there is no version constraint (bare package name).
+    pub fn satisfied_by(&self, installed_version: &str) -> bool {
+        let (Some(op), Some(req_ver)) = (&self.op, &self.version) else {
+            return true;
+        };
+
+        let ord = version_compare2(installed_version, req_ver);
+        match op {
+            DepOp::Ge => ord != Ordering::Less,
+            DepOp::Le => ord != Ordering::Greater,
+            DepOp::Gt => ord == Ordering::Greater,
+            DepOp::Lt => ord == Ordering::Less,
+            DepOp::Eq => ord == Ordering::Equal,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_bare() {
+        let d = DepConstraint::parse("curl").unwrap();
+        assert_eq!(d.name, "curl");
+        assert!(d.op.is_none());
+        assert!(d.version.is_none());
+    }
+
+    #[test]
+    fn parse_ge() {
+        let d = DepConstraint::parse("openssl>=3.0").unwrap();
+        assert_eq!(d.name, "openssl");
+        assert_eq!(d.op, Some(DepOp::Ge));
+        assert_eq!(d.version.as_deref(), Some("3.0"));
+    }
+
+    #[test]
+    fn parse_ge_not_gt() {
+        // Make sure ">=" isn't parsed as ">" with "=3.0" as version
+        let d = DepConstraint::parse("openssl>=3.0").unwrap();
+        assert_eq!(d.op, Some(DepOp::Ge));
+        assert_eq!(d.version.as_deref(), Some("3.0"));
+    }
+
+    #[test]
+    fn parse_eq() {
+        let d = DepConstraint::parse("gcc=14.1.0").unwrap();
+        assert_eq!(d.op, Some(DepOp::Eq));
+        assert_eq!(d.version.as_deref(), Some("14.1.0"));
+    }
+
+    #[test]
+    fn parse_lt() {
+        let d = DepConstraint::parse("python<4").unwrap();
+        assert_eq!(d.op, Some(DepOp::Lt));
+        assert_eq!(d.version.as_deref(), Some("4"));
+    }
+
+    #[test]
+    fn satisfied_bare() {
+        let d = DepConstraint::parse("curl").unwrap();
+        assert!(d.satisfied_by("7.88.1"));
+        assert!(d.satisfied_by("anything"));
+    }
+
+    #[test]
+    fn satisfied_ge() {
+        let d = DepConstraint::parse("openssl>=3.0").unwrap();
+        assert!(d.satisfied_by("3.0"));
+        assert!(d.satisfied_by("3.4.1"));
+        assert!(!d.satisfied_by("2.9.9"));
+    }
+
+    #[test]
+    fn satisfied_eq() {
+        let d = DepConstraint::parse("gcc=14.1.0").unwrap();
+        assert!(d.satisfied_by("14.1.0"));
+        assert!(!d.satisfied_by("14.1.1"));
+        assert!(!d.satisfied_by("13.2.0"));
+    }
+}

--- a/crates/koca/src/dep.rs
+++ b/crates/koca/src/dep.rs
@@ -76,7 +76,7 @@ impl DepConstraint {
             if let Some((name, ver)) = s.split_once(op_str) {
                 let name = name.trim();
                 let ver = ver.trim();
-                if name.is_empty() {
+                if name.is_empty() || ver.is_empty() {
                     return Err(KocaError::InvalidDep(s.to_string()));
                 }
                 return Ok(Self {

--- a/crates/koca/src/distro.rs
+++ b/crates/koca/src/distro.rs
@@ -1,0 +1,133 @@
+use std::{fs, str::FromStr};
+
+use crate::{KocaError, KocaResult};
+
+/// The detected (or user-specified) target distribution.
+#[derive(Debug, Clone)]
+pub struct Distro {
+    pub id: String,
+    pub version_id: Option<String>,
+}
+
+impl Distro {
+    /// Detect the current distro by reading `/etc/os-release`.
+    pub fn detect() -> KocaResult<Self> {
+        let content = fs::read_to_string("/etc/os-release").map_err(KocaError::IO)?;
+        Self::parse_os_release(&content)
+    }
+
+    fn parse_os_release(content: &str) -> KocaResult<Self> {
+        let mut id: Option<String> = None;
+        let mut version_id: Option<String> = None;
+
+        for line in content.lines() {
+            let line = line.trim();
+            if let Some(val) = line.strip_prefix("ID=") {
+                id = Some(unquote(val).to_string());
+            } else if let Some(val) = line.strip_prefix("VERSION_ID=") {
+                version_id = Some(unquote(val).to_string());
+            }
+        }
+
+        let id = id.ok_or_else(|| {
+            KocaError::IO(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "ID not found in /etc/os-release",
+            ))
+        })?;
+
+        Ok(Self { id, version_id })
+    }
+
+    /// Returns the repology repository name for this distro.
+    ///
+    /// Examples: `"arch"`, `"debian_12"`, `"ubuntu_24_04"`
+    pub fn repology_repo(&self) -> String {
+        match self.id.as_str() {
+            "arch" | "manjaro" | "endeavouros" | "garuda" => "arch".into(),
+            "debian" => {
+                let ver = self.version_id.as_deref().unwrap_or("").replace('.', "_");
+                format!("debian_{ver}")
+            }
+            "ubuntu" => {
+                let ver = self.version_id.as_deref().unwrap_or("").replace('.', "_");
+                format!("ubuntu_{ver}")
+            }
+            "fedora" => {
+                let ver = self.version_id.as_deref().unwrap_or("");
+                format!("fedora_{ver}")
+            }
+            other => other.to_string(),
+        }
+    }
+
+    /// Returns the backend binary name to use for this distro.
+    pub fn backend_binary(&self) -> &str {
+        match self.id.as_str() {
+            "arch" | "manjaro" | "endeavouros" | "garuda" => "koca-backend-alpm",
+            "debian" | "ubuntu" | "linuxmint" | "pop" => "koca-backend-apt",
+            _ => "koca-backend-alpm",
+        }
+    }
+}
+
+impl FromStr for Distro {
+    type Err = KocaError;
+
+    /// Parse a `--target` override string like `"arch"` or `"debian:12"`.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Some((id, ver)) = s.split_once(':') {
+            Ok(Self {
+                id: id.to_string(),
+                version_id: Some(ver.to_string()),
+            })
+        } else {
+            Ok(Self {
+                id: s.to_string(),
+                version_id: None,
+            })
+        }
+    }
+}
+
+fn unquote(s: &str) -> &str {
+    let s = s.trim();
+    if (s.starts_with('"') && s.ends_with('"')) || (s.starts_with('\'') && s.ends_with('\'')) {
+        &s[1..s.len() - 1]
+    } else {
+        s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_arch() {
+        let d = Distro::parse_os_release("ID=arch\n").unwrap();
+        assert_eq!(d.id, "arch");
+        assert_eq!(d.repology_repo(), "arch");
+        assert_eq!(d.backend_binary(), "koca-backend-alpm");
+    }
+
+    #[test]
+    fn parse_debian_quoted() {
+        let d = Distro::parse_os_release("ID=debian\nVERSION_ID=\"12\"\n").unwrap();
+        assert_eq!(d.repology_repo(), "debian_12");
+        assert_eq!(d.backend_binary(), "koca-backend-apt");
+    }
+
+    #[test]
+    fn parse_ubuntu() {
+        let d = Distro::parse_os_release("ID=ubuntu\nVERSION_ID=\"24.04\"\n").unwrap();
+        assert_eq!(d.repology_repo(), "ubuntu_24_04");
+    }
+
+    #[test]
+    fn from_str_with_version() {
+        let d: Distro = "debian:12".parse().unwrap();
+        assert_eq!(d.id, "debian");
+        assert_eq!(d.version_id.as_deref(), Some("12"));
+    }
+}

--- a/crates/koca/src/error.rs
+++ b/crates/koca/src/error.rs
@@ -63,4 +63,7 @@ pub enum KocaError {
     /// An error occurred while executing a Koca build file function.
     #[error("failed to execute function '{0}'")]
     FuncError(KocaFunction),
+    /// An invalid dependency constraint string.
+    #[error("invalid dependency constraint: '{0}'")]
+    InvalidDep(String),
 }

--- a/crates/koca/src/file/mod.rs
+++ b/crates/koca/src/file/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     KocaError, KocaMultiResult, KocaParserError, KocaResult,
 };
 pub use arch::Arch;
-use brush::{env::EnvironmentScope, CreateOptions, Shell, ShellVariable};
+use brush::{CreateOptions, Shell, ShellVariable};
 use brush_parser::{ast::FunctionDefinition, word::WordPiece};
 use itertools::Itertools;
 use nfpm_sys::NfpmError;
@@ -16,11 +16,11 @@ use std::{
     collections::HashMap,
     env, fmt,
     fs::{self, File},
-    io::Read,
-    mem,
+    io::{BufRead, BufReader, Read},
     path::{self, Path},
     str::FromStr,
 };
+use tokio::sync::mpsc;
 pub use version::{PkgVersion, Version};
 
 /// The output bundle format.
@@ -32,12 +32,31 @@ pub enum BundleFormat {
 }
 
 impl BundleFormat {
-    /// Convert the output type to a `nfpm` bundle format.
-    pub fn to_nfpm_format(&self) -> &str {
+    /// File extension for this bundle format (also the nfpm format string).
+    pub fn extension(&self) -> &'static str {
         match self {
             BundleFormat::Deb => "deb",
             BundleFormat::Rpm => "rpm",
         }
+    }
+
+    /// Return the architecture string appropriate for this format.
+    pub fn arch_string(&self, arch: &Arch) -> &'static str {
+        match self {
+            BundleFormat::Deb => arch.get_deb_string(),
+            BundleFormat::Rpm => arch.get_rpm_string(),
+        }
+    }
+
+    /// Build the output filename for a package in this format.
+    pub fn output_filename(&self, pkgname: &str, version: &str, arch: &Arch) -> String {
+        format!(
+            "{}_{}_{}.{}",
+            pkgname,
+            version,
+            self.arch_string(arch),
+            self.extension()
+        )
     }
 }
 
@@ -59,6 +78,18 @@ impl fmt::Display for KocaFunction {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BuildOutputStream {
+    Stdout,
+    Stderr,
+}
+
+#[derive(Debug, Clone)]
+pub struct BuildOutputLine {
+    pub stream: BuildOutputStream,
+    pub line: String,
+}
+
 /// A package's Koca build file.
 pub struct BuildFile {
     /// The [`Shell`] instance to use.
@@ -73,8 +104,10 @@ pub struct BuildFile {
     var_arch: Vec<Arch>,
     /// The package's description.
     var_pkgdesc: String,
-    /// The package's runtime dependencies.
-    var_depends: Vec<String>,
+    /// The package's runtime dependencies (repology project names + optional version constraints).
+    var_depends: Vec<crate::dep::DepConstraint>,
+    /// The package's build-time dependencies (repology project names + optional version constraints).
+    var_makedepends: Vec<crate::dep::DepConstraint>,
     /// The package's `build` function.
     build_func: FunctionDefinition,
     /// The package's `package` function.
@@ -157,6 +190,26 @@ impl BuildFile {
         Ok(result)
     }
 
+    /// Parse a string array into `Vec<DepConstraint>`, propagating parse errors.
+    fn parse_dep_array(
+        var_name: &str,
+        value: &DeclValue,
+    ) -> KocaMultiResult<Vec<crate::dep::DepConstraint>> {
+        let strings = Self::parse_string_array(var_name, value)?;
+        let mut errs = vec![];
+        let mut result = vec![];
+        for s in strings {
+            match crate::dep::DepConstraint::parse(&s) {
+                Ok(dep) => result.push(dep),
+                Err(err) => errs.push(err),
+            }
+        }
+        if !errs.is_empty() {
+            return Err(errs);
+        }
+        Ok(result)
+    }
+
     /// Parse a [`DeclValue`] into an `arch`.
     fn parse_arch(value: &DeclValue) -> KocaMultiResult<Vec<Arch>> {
         let mut errs = vec![];
@@ -182,7 +235,7 @@ impl BuildFile {
     pub async fn parse<R: Read>(reader: R) -> KocaMultiResult<Self> {
         // Create the shell.
         let create_options = Self::create_options();
-        let shell = Shell::new(&create_options)
+        let shell = Shell::new(create_options)
             .await
             .expect("shell options should be valid");
         let program = shell
@@ -197,7 +250,8 @@ impl BuildFile {
         let mut opt_epoch: Option<String> = None;
         let mut opt_arch: Option<Vec<Arch>> = None;
         let mut opt_pkgdesc: Option<String> = None;
-        let mut opt_depends: Vec<String> = vec![];
+        let mut opt_depends: Vec<crate::dep::DepConstraint> = vec![];
+        let mut opt_makedepends: Vec<crate::dep::DepConstraint> = vec![];
 
         let mut opt_build_func: Option<FunctionDefinition> = None;
         let mut opt_package_func: Option<FunctionDefinition> = None;
@@ -231,8 +285,12 @@ impl BuildFile {
                     Ok(pkgdesc) => opt_pkgdesc = Some(pkgdesc),
                     Err(err) => errs.push(err),
                 },
-                vars::DEPENDS => match Self::parse_string_array(vars::DEPENDS, value) {
+                vars::DEPENDS => match Self::parse_dep_array(vars::DEPENDS, value) {
                     Ok(depends) => opt_depends = depends,
+                    Err(dep_errs) => errs.extend(dep_errs),
+                },
+                vars::MAKEDEPENDS => match Self::parse_dep_array(vars::MAKEDEPENDS, value) {
+                    Ok(makedepends) => opt_makedepends = makedepends,
                     Err(dep_errs) => errs.extend(dep_errs),
                 },
                 _ => continue,
@@ -241,7 +299,7 @@ impl BuildFile {
 
         // Extract functions.
         for func in decl_items.funcs {
-            match func.fname.as_str() {
+            match func.fname.value.as_str() {
                 funcs::BUILD => opt_build_func = Some(func),
                 funcs::PACKAGE => opt_package_func = Some(func),
                 _ => continue,
@@ -306,6 +364,7 @@ impl BuildFile {
             var_arch: opt_arch.expect("arch should be set"),
             var_pkgdesc: opt_pkgdesc.expect("pkgdesc should be set"),
             var_depends: opt_depends,
+            var_makedepends: opt_makedepends,
             build_func: opt_build_func.expect("build function should be set"),
             package_func: opt_package_func.expect("package function should be set"),
         })
@@ -325,7 +384,7 @@ impl BuildFile {
     fn add_vars(&mut self) {
         // Add inherited vars.
         for (key, var) in env::vars() {
-            let mut shell_var = ShellVariable::new(var.into());
+            let mut shell_var = ShellVariable::new(var);
             shell_var.export();
             self.shell
                 .set_env_global(&key, shell_var)
@@ -335,11 +394,11 @@ impl BuildFile {
         // Add built-in vars.
         for (key, var) in &self.vars {
             let shell_var = match var {
-                DeclValue::String(val) => ShellVariable::new(val.value.clone().into()),
+                DeclValue::String(val) => ShellVariable::new(val.value.clone()),
                 DeclValue::Array(vals) => {
                     let string_values: Vec<String> =
                         vals.iter().map(|word| word.value.clone()).collect();
-                    ShellVariable::new(string_values.into())
+                    ShellVariable::new(string_values)
                 }
             };
 
@@ -355,28 +414,17 @@ impl BuildFile {
     /// - [`KocaError::IO`] if the build directory couldn't be created.
     /// - [`KocaError::Func`] if the `build` function failed to execute.
     pub async fn run_build(&mut self) -> KocaResult<()> {
-        self.shell.funcs.clear();
-        self.shell.funcs.update(
-            self.build_func.fname.clone(),
-            self.build_func.clone().into(),
-        );
+        self.run_build_with_output(|_| {}).await
+    }
 
-        self.add_vars();
-
-        let existing_dir = mem::replace(&mut self.shell.working_dir, dirs::SRC.into());
-        fs::create_dir_all(dirs::SRC)?;
-
-        let exit_code = self
-            .shell
-            .invoke_function(&self.build_func.fname, &[])
-            .await?;
-        if exit_code != 0 {
-            return Err(KocaError::FuncError(KocaFunction::Build));
-        }
-
-        self.shell.working_dir = existing_dir;
-
-        Ok(())
+    /// Run `build()` with a callback. Called with `Some(line)` for output,
+    /// `None` every ~80ms for tick/spinner animation.
+    pub async fn run_build_with_output(
+        &mut self,
+        callback: impl FnMut(Option<BuildOutputLine>),
+    ) -> KocaResult<()> {
+        self.run_function_with_output(KocaFunction::Build, self.build_func.clone(), None, callback)
+            .await
     }
 
     /// Run the `package` function of the package.
@@ -384,48 +432,126 @@ impl BuildFile {
     /// - [`KocaError::IO`] if the package directory couldn't be created.
     /// - [`KocaError::Func`] if the `package` function failed to execute.
     pub async fn run_package(&mut self) -> KocaResult<()> {
-        self.shell.funcs.clear();
-        self.shell.funcs.update(
-            self.package_func.fname.clone(),
-            self.package_func.clone().into(),
-        );
+        self.run_package_with_output(|_| {}).await
+    }
 
-        self.add_vars();
-
-        let existing_dir = mem::replace(&mut self.shell.working_dir, dirs::SRC.into());
-        fs::create_dir_all(dirs::PKG)?;
-
+    pub async fn run_package_with_output(
+        &mut self,
+        callback: impl FnMut(Option<BuildOutputLine>),
+    ) -> KocaResult<()> {
         let absolute_pkgdir = path::absolute(dirs::PKG)
             .expect("directory should exist at this point")
             .to_string_lossy()
             .into_owned();
-        self.shell
-            .env
-            .add(
-                "pkgdir",
-                ShellVariable::new(absolute_pkgdir.into()),
-                EnvironmentScope::Global,
-            )
-            .expect("shell adding shouldn't fail");
 
-        let exit_code = self
-            .shell
-            .invoke_function(&self.package_func.fname, &[])
-            .await?;
-        if exit_code != 0 {
-            return Err(KocaError::FuncError(KocaFunction::Package));
+        self.run_function_with_output(
+            KocaFunction::Package,
+            self.package_func.clone(),
+            Some(("pkgdir", absolute_pkgdir)),
+            callback,
+        )
+        .await
+    }
+
+    async fn run_function_with_output(
+        &mut self,
+        function_kind: KocaFunction,
+        function: FunctionDefinition,
+        extra_env: Option<(&str, String)>,
+        mut callback: impl FnMut(Option<BuildOutputLine>),
+    ) -> KocaResult<()> {
+        self.shell.undefine_func(funcs::BUILD);
+        self.shell.undefine_func(funcs::PACKAGE);
+        self.shell
+            .define_func(function.fname.value.clone(), function.clone());
+
+        self.add_vars();
+        fs::create_dir_all(dirs::SRC)?;
+        if matches!(function_kind, KocaFunction::Package) {
+            fs::create_dir_all(dirs::PKG)?;
         }
-        self.shell.working_dir = existing_dir;
+
+        if let Some((name, value)) = extra_env {
+            self.shell
+                .set_env_global(name, ShellVariable::new(value))
+                .expect("setting environment variable shouldn't fail");
+        }
+
+        let existing_dir = self.shell.working_dir().to_path_buf();
+        self.shell.set_working_dir(dirs::SRC)?;
+
+        let result = self
+            .invoke_function_with_output(function.fname.value.as_str(), &mut callback)
+            .await;
+
+        self.shell.set_working_dir(existing_dir)?;
+
+        let exit_code = result?;
+        if exit_code != 0 {
+            return Err(KocaError::FuncError(function_kind));
+        }
 
         Ok(())
     }
 
+    async fn invoke_function_with_output(
+        &mut self,
+        function_name: &str,
+        callback: &mut impl FnMut(Option<BuildOutputLine>),
+    ) -> KocaResult<u8> {
+        let (stdout_reader, stdout_writer) = std::io::pipe()?;
+        let (stderr_reader, stderr_writer) = std::io::pipe()?;
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let stdout_handle =
+            spawn_output_reader(stdout_reader, BuildOutputStream::Stdout, tx.clone());
+        let stderr_handle = spawn_output_reader(stderr_reader, BuildOutputStream::Stderr, tx);
+
+        let mut params = self.shell.default_exec_params();
+        params.set_fd(1, stdout_writer.into());
+        params.set_fd(2, stderr_writer.into());
+
+        let mut ticker = tokio::time::interval(std::time::Duration::from_millis(80));
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        let exit_code = {
+            let invoke_params = params.clone();
+            let mut invoke = std::pin::pin!(self.shell.invoke_function(
+                function_name,
+                std::iter::empty::<&str>(),
+                &invoke_params
+            ));
+
+            loop {
+                tokio::select! {
+                    result = &mut invoke => break result?,
+                    maybe_line = rx.recv() => {
+                        if let Some(line) = maybe_line {
+                            callback(Some(line));
+                        }
+                    }
+                    _ = ticker.tick() => {
+                        callback(None);
+                    }
+                }
+            }
+        };
+
+        drop(params);
+
+        while let Some(line) = rx.recv().await {
+            callback(Some(line));
+        }
+
+        let _ = stdout_handle.join();
+        let _ = stderr_handle.join();
+
+        Ok(exit_code)
+    }
+
     /// Bundle the package into the given file format.
     pub async fn bundle(&self, format: BundleFormat, out_file: &Path) -> KocaResult<()> {
-        let system_arch = match format {
-            BundleFormat::Deb => self.var_arch[0].get_deb_string(),
-            BundleFormat::Rpm => self.var_arch[0].get_rpm_string(),
-        };
+        let system_arch = format.arch_string(&self.var_arch[0]);
 
         let config = NfpmConfig {
             name: self.var_pkgname.clone(),
@@ -442,7 +568,7 @@ impl BuildFile {
             description: self.var_pkgdesc.clone(),
             // TODO: We need to check for this somehow - figure out what the build file implementation looks like.
             license: "CONTACT-PUBLISHER".to_string(),
-            depends: self.var_depends.clone(),
+            depends: self.var_depends.iter().map(|d| d.to_string()).collect(),
             contents: nfpm::get_nfpm_files(Path::new(dirs::PKG)),
         };
         let config_json =
@@ -457,7 +583,7 @@ impl BuildFile {
         // Build with `nfpm`.
         let nfpm_res = nfpm_sys::run_bundle(
             &out_file.display().to_string(),
-            format.to_nfpm_format(),
+            format.extension(),
             &config_json,
         );
 
@@ -492,6 +618,45 @@ impl BuildFile {
     pub fn pkgdesc(&self) -> &str {
         &self.var_pkgdesc
     }
+
+    /// Get the package's runtime dependency constraints.
+    pub fn depends(&self) -> &[crate::dep::DepConstraint] {
+        &self.var_depends
+    }
+
+    /// Get the package's build-time dependency constraints.
+    pub fn makedepends(&self) -> &[crate::dep::DepConstraint] {
+        &self.var_makedepends
+    }
+}
+
+fn spawn_output_reader(
+    reader: std::io::PipeReader,
+    stream: BuildOutputStream,
+    tx: mpsc::UnboundedSender<BuildOutputLine>,
+) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        let mut reader = BufReader::new(reader);
+        let mut line = String::new();
+
+        loop {
+            line.clear();
+            match reader.read_line(&mut line) {
+                Ok(0) => break,
+                Ok(_) => {
+                    while line.ends_with('\n') || line.ends_with('\r') {
+                        line.pop();
+                    }
+
+                    let _ = tx.send(BuildOutputLine {
+                        stream,
+                        line: line.clone(),
+                    });
+                }
+                Err(_) => break,
+            }
+        }
+    })
 }
 
 /// A mapping of `const` variable names to their stringified values.
@@ -503,6 +668,7 @@ pub mod vars {
     pub const ARCH: &str = "arch";
     pub const PKGDESC: &str = "pkgdesc";
     pub const DEPENDS: &str = "depends";
+    pub const MAKEDEPENDS: &str = "makedepends";
 }
 
 /// A mapping of `const` function names to their stringified values.

--- a/crates/koca/src/lib.rs
+++ b/crates/koca/src/lib.rs
@@ -3,8 +3,12 @@
 //! The entry point to the library is the [`BuildFile`].
 #![allow(clippy::result_large_err)]
 
+pub mod backend;
+pub mod dep;
+pub mod distro;
 mod error;
 mod file;
 mod nfpm;
+pub mod resolve;
 pub use error::*;
 pub use file::*;

--- a/crates/koca/src/resolve.rs
+++ b/crates/koca/src/resolve.rs
@@ -1,0 +1,100 @@
+use repology::RepologyClient;
+
+use crate::{dep::DepConstraint, KocaError, KocaResult};
+
+/// A dependency constraint resolved to one or more native package names on a
+/// specific distro.
+#[derive(Debug, Clone)]
+pub struct ResolvedDep {
+    /// The original constraint from the `.koca` file.
+    pub constraint: DepConstraint,
+    /// Native package name(s) for the target distro.
+    /// Most projects map to a single name; some (e.g. split packages) map to
+    /// multiple.
+    pub native_names: Vec<String>,
+}
+
+impl ResolvedDep {
+    /// The display string for the constraint, e.g. `"openssl>=3.0"`.
+    pub fn display_constraint(&self) -> String {
+        self.constraint.to_string()
+    }
+}
+
+/// Resolve a list of repology project constraints to native package names for
+/// the target distro repository.
+///
+/// Hard-fails if repology is unreachable or a project has no package for the
+/// target repo.
+pub async fn resolve_deps(deps: &[DepConstraint], repo: &str) -> KocaResult<Vec<ResolvedDep>> {
+    if deps.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let client = RepologyClient::builder()
+        .user_agent(concat!("koca/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(|e| {
+            KocaError::IO(std::io::Error::other(format!(
+                "failed to build repology client: {e}"
+            )))
+        })?;
+
+    let mut resolved = Vec::with_capacity(deps.len());
+
+    for dep in deps {
+        let packages = client.project(&dep.name).await.map_err(|e| {
+            KocaError::IO(std::io::Error::other(format!(
+                "repology lookup failed for '{}': {e}\n\
+                 Ensure you have network access to repology.org.",
+                dep.name
+            )))
+        })?;
+
+        let matching: Vec<_> = packages.iter().filter(|p| p.repo == repo).collect();
+
+        if matching.is_empty() {
+            return Err(KocaError::IO(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!(
+                    "repology project '{}' has no package for distro repo '{repo}'.\n\
+                     Check the project name at https://repology.org/project/{}/versions",
+                    dep.name, dep.name
+                ),
+            )));
+        }
+
+        // Collect all binary names. Some projects map to multiple packages
+        // (e.g. split packages). We install all of them.
+        let mut native_names: Vec<String> = Vec::new();
+        for pkg in &matching {
+            if let Some(names) = &pkg.binnames {
+                native_names.extend(names.iter().cloned());
+            } else if let Some(name) = &pkg.binname {
+                native_names.push(name.clone());
+            } else if let Some(name) = &pkg.srcname {
+                native_names.push(name.clone());
+            } else {
+                // Fall back to the repology project name
+                native_names.push(dep.name.clone());
+            }
+        }
+        native_names.sort();
+        native_names.dedup();
+
+        resolved.push(ResolvedDep {
+            constraint: dep.clone(),
+            native_names,
+        });
+    }
+
+    Ok(resolved)
+}
+
+/// Flatten a list of resolved deps into a plain list of native package names.
+pub fn native_names(resolved: &[ResolvedDep]) -> Vec<String> {
+    resolved
+        .iter()
+        .flat_map(|r| r.native_names.iter().cloned())
+        .collect()
+}

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "koca-proto"
+version.workspace = true
+edition.workspace = true
+license = "MIT"
+
+[dependencies]
+clap = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+interprocess = { workspace = true }

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -1,0 +1,21 @@
+use thiserror::Error;
+
+use crate::types::ProtocolError;
+
+#[derive(Debug, Error)]
+pub enum ProtoError {
+    #[error("I/O error: {0}")]
+    Io(std::io::Error),
+
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("socket error: {0}")]
+    Socket(std::io::Error),
+
+    #[error("connection closed unexpectedly")]
+    ConnectionClosed,
+
+    #[error("backend error: {0}")]
+    Backend(ProtocolError),
+}

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -1,0 +1,11 @@
+pub mod error;
+pub mod transport;
+pub mod types;
+
+pub use error::ProtoError;
+pub use transport::{socket_name, BackendSession, KocaListener, KocaSession};
+pub use types::{
+    ActionKind, BackendArgs, Command, DownloadEvent, ErrorCode, Event, InstallEvent,
+    InstalledStatus, Message, MessageBody, PackageStatus, PlannedAction, ProtocolError,
+    RemoveEvent, Request, ResultPayload,
+};

--- a/crates/proto/src/transport.rs
+++ b/crates/proto/src/transport.rs
@@ -1,0 +1,265 @@
+use std::path::PathBuf;
+
+use interprocess::local_socket::{
+    prelude::*, tokio::prelude::*, GenericFilePath, GenericNamespaced, ListenerOptions,
+};
+use tokio::{
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+    sync::mpsc,
+};
+
+use crate::{
+    error::ProtoError,
+    types::{Command, Message, MessageBody, Request, ResultPayload},
+};
+
+/// Generate a unique socket name for this process.
+pub fn socket_name() -> String {
+    format!("koca-backend-{}", std::process::id())
+}
+
+fn make_name(name: &str) -> Result<interprocess::local_socket::Name<'static>, ProtoError> {
+    if GenericNamespaced::is_supported() {
+        name.to_owned()
+            .to_ns_name::<GenericNamespaced>()
+            .map_err(ProtoError::Socket)
+    } else {
+        PathBuf::from(format!("/tmp/{name}"))
+            .to_fs_name::<GenericFilePath>()
+            .map_err(ProtoError::Socket)
+    }
+}
+
+type TokioStream = interprocess::local_socket::tokio::Stream;
+
+// ── KocaSession (parent / koca side) ─────────────────────────────────────
+
+/// koca's session handle to a running backend process.
+///
+/// A background tokio task continuously reads from the socket and buffers
+/// messages into an internal channel. This means:
+/// - `try_recv()` is always non-blocking — returns `None` if no message ready.
+/// - The TUI render loop ticks at a fixed interval, drains all buffered events,
+///   then renders once. No `tokio::select!` needed.
+///
+/// ```rust,ignore
+/// session.send(Command::Confirm).await?;
+/// let mut ticker = tokio::time::interval(Duration::from_millis(80));
+/// let result = 'outer: loop {
+///     ticker.tick().await;
+///     state.tick += 1;
+///     loop {
+///         match session.try_recv()? {
+///             None => break,
+///             Some(MessageBody::Event { event })   => state.apply(event),
+///             Some(MessageBody::Result { result })  => break 'outer result,
+///             Some(MessageBody::Error { error })    => return Err(error.into()),
+///         }
+///     }
+///     vp.draw(height, |f| render(f, &state));
+/// };
+/// ```
+pub struct KocaSession {
+    /// Write half of the socket — for sending requests to the backend.
+    writer: tokio::io::WriteHalf<TokioStream>,
+    /// Buffered messages from the background reader task.
+    receiver: mpsc::Receiver<Result<MessageBody, ProtoError>>,
+    next_id: u64,
+}
+
+impl KocaSession {
+    fn new(stream: TokioStream) -> Self {
+        let (read, write) = tokio::io::split(stream);
+        let (tx, rx) = mpsc::channel(64);
+
+        // Background task: drain socket → channel.
+        // Exits when the channel is dropped (KocaSession dropped) or on error.
+        tokio::spawn(async move {
+            let mut reader = BufReader::new(read);
+            loop {
+                let mut line = String::new();
+                match reader.read_line(&mut line).await {
+                    Err(e) => {
+                        let _ = tx.send(Err(ProtoError::Io(e))).await;
+                        break;
+                    }
+                    Ok(0) => {
+                        // EOF — connection closed by backend
+                        let _ = tx.send(Err(ProtoError::ConnectionClosed)).await;
+                        break;
+                    }
+                    Ok(_) => {
+                        let result = serde_json::from_str::<Message>(&line)
+                            .map(|m| m.body)
+                            .map_err(ProtoError::Json);
+                        if tx.send(result).await.is_err() {
+                            // KocaSession was dropped; stop reading
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+
+        Self {
+            writer: write,
+            receiver: rx,
+            next_id: 1,
+        }
+    }
+
+    fn next_id(&mut self) -> u64 {
+        let id = self.next_id;
+        self.next_id += 1;
+        id
+    }
+
+    async fn write_request(&mut self, req: &Request) -> Result<(), ProtoError> {
+        let mut line = serde_json::to_string(req).map_err(ProtoError::Json)?;
+        line.push('\n');
+        self.writer
+            .write_all(line.as_bytes())
+            .await
+            .map_err(ProtoError::Io)?;
+        self.writer.flush().await.map_err(ProtoError::Io)?;
+        Ok(())
+    }
+
+    // ── Public API ────────────────────────────────────────────────────────
+
+    /// Non-blocking poll.
+    ///
+    /// - `Ok(None)` — no message buffered yet; keep going.
+    /// - `Ok(Some(body))` — a message is ready.
+    /// - `Err(e)` — the connection died.
+    pub fn try_recv(&mut self) -> Result<Option<MessageBody>, ProtoError> {
+        match self.receiver.try_recv() {
+            Ok(Ok(body)) => Ok(Some(body)),
+            Ok(Err(e)) => Err(e),
+            Err(mpsc::error::TryRecvError::Empty) => Ok(None),
+            Err(mpsc::error::TryRecvError::Disconnected) => Err(ProtoError::ConnectionClosed),
+        }
+    }
+
+    /// Blocking async recv. Awaits until the next message arrives.
+    ///
+    /// Used internally by `call()`. Prefer `try_recv()` in TUI loops.
+    async fn recv(&mut self) -> Result<MessageBody, ProtoError> {
+        match self.receiver.recv().await {
+            Some(Ok(body)) => Ok(body),
+            Some(Err(e)) => Err(e),
+            None => Err(ProtoError::ConnectionClosed),
+        }
+    }
+
+    /// Simple request/response for commands that don't stream events
+    /// (e.g. `check-installed`, `abort`). Awaits until the result arrives.
+    pub async fn call(&mut self, cmd: Command) -> Result<ResultPayload, ProtoError> {
+        let id = self.next_id();
+        self.write_request(&Request { id, cmd }).await?;
+        loop {
+            match self.recv().await? {
+                MessageBody::Result { result } => return Ok(result),
+                MessageBody::Error { error } => return Err(ProtoError::Backend(error)),
+                MessageBody::Event { .. } => {} // unexpected; ignore
+            }
+        }
+    }
+
+    /// Send a command without waiting for a response.
+    ///
+    /// Use for streaming commands (`confirm`, `remove`) where the TUI loop
+    /// drives consumption via `try_recv()`.
+    pub async fn send(&mut self, cmd: Command) -> Result<u64, ProtoError> {
+        let id = self.next_id();
+        self.write_request(&Request { id, cmd }).await?;
+        Ok(id)
+    }
+
+    /// Send a `Shutdown` command. The caller is responsible for waiting on the
+    /// child process afterwards (`child.wait().await`).
+    pub async fn shutdown(mut self) -> Result<(), ProtoError> {
+        let id = self.next_id();
+        // Best-effort during shutdown — ignore send errors
+        let _ = self
+            .write_request(&Request {
+                id,
+                cmd: Command::Shutdown,
+            })
+            .await;
+        Ok(())
+    }
+}
+
+/// Listens for the backend to connect. Create this **before** spawning the
+/// backend process, then pass the socket name to the backend via `--socket`.
+pub struct KocaListener {
+    listener: interprocess::local_socket::tokio::Listener,
+}
+
+impl KocaListener {
+    pub fn listen(name: &str) -> Result<Self, ProtoError> {
+        let socket_name = make_name(name)?;
+        let listener = ListenerOptions::new()
+            .name(socket_name)
+            .create_tokio()
+            .map_err(ProtoError::Io)?;
+        Ok(Self { listener })
+    }
+
+    pub async fn accept(self) -> Result<KocaSession, ProtoError> {
+        let stream = self.listener.accept().await.map_err(ProtoError::Io)?;
+        Ok(KocaSession::new(stream))
+    }
+}
+
+// ── BackendSession (child / backend side) ─────────────────────────────────
+
+/// The backend's session handle back to koca.
+///
+/// The backend processes one request at a time and may freely block on `recv()`.
+pub struct BackendSession {
+    reader: BufReader<tokio::io::ReadHalf<TokioStream>>,
+    writer: tokio::io::WriteHalf<TokioStream>,
+}
+
+impl BackendSession {
+    /// Connect to the socket that koca is listening on.
+    /// Pass the value of the `--socket` argument here.
+    pub async fn connect(name: &str) -> Result<Self, ProtoError> {
+        let socket_name = make_name(name)?;
+        let stream = TokioStream::connect(socket_name)
+            .await
+            .map_err(ProtoError::Io)?;
+        let (read, write) = tokio::io::split(stream);
+        Ok(Self {
+            reader: BufReader::new(read),
+            writer: write,
+        })
+    }
+
+    /// Wait for the next request from koca. The backend can block here freely.
+    pub async fn recv(&mut self) -> Result<Request, ProtoError> {
+        let mut line = String::new();
+        self.reader
+            .read_line(&mut line)
+            .await
+            .map_err(ProtoError::Io)?;
+        if line.is_empty() {
+            return Err(ProtoError::ConnectionClosed);
+        }
+        serde_json::from_str(&line).map_err(ProtoError::Json)
+    }
+
+    /// Send any message (result, event, or error) to koca.
+    pub async fn send(&mut self, msg: &Message) -> Result<(), ProtoError> {
+        let mut line = serde_json::to_string(msg).map_err(ProtoError::Json)?;
+        line.push('\n');
+        self.writer
+            .write_all(line.as_bytes())
+            .await
+            .map_err(ProtoError::Io)?;
+        self.writer.flush().await.map_err(ProtoError::Io)?;
+        Ok(())
+    }
+}

--- a/crates/proto/src/types.rs
+++ b/crates/proto/src/types.rs
@@ -1,0 +1,238 @@
+use clap::Parser;
+use serde::{Deserialize, Serialize};
+
+// ── Backend CLI args (shared across all backends) ─────────────────────────
+
+/// CLI arguments shared by all koca backend binaries.
+///
+/// Each backend binary uses this as its top-level clap struct:
+/// ```rust,ignore
+/// let args = BackendArgs::parse();
+/// let session = BackendSession::connect(&args.socket).await?;
+/// ```
+#[derive(Debug, Parser)]
+#[command(about = "koca package manager backend")]
+pub struct BackendArgs {
+    /// Socket name to connect back to koca (created by the koca parent process).
+    #[arg(long)]
+    pub socket: String,
+}
+
+// ── Requests (koca → backend) ─────────────────────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Request {
+    pub id: u64,
+    #[serde(flatten)]
+    pub cmd: Command,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "cmd", rename_all = "kebab-case")]
+pub enum Command {
+    CheckInstalled { packages: Vec<String> },
+    InstallPlan { packages: Vec<String> },
+    Confirm,
+    Abort,
+    Remove { packages: Vec<String> },
+    Shutdown,
+}
+
+// ── Responses (backend → koca) ────────────────────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Message {
+    pub id: u64,
+    #[serde(flatten)]
+    pub body: MessageBody,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "kebab-case")]
+pub enum MessageBody {
+    Result { result: ResultPayload },
+    Event { event: Event },
+    Error { error: ProtocolError },
+}
+
+// ── Result payloads ───────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "kebab-case")]
+pub enum ResultPayload {
+    CheckInstalled {
+        packages: Vec<PackageStatus>,
+    },
+    InstallPlan {
+        actions: Vec<PlannedAction>,
+        total_download: u64,
+        total_install: u64,
+    },
+    Install {
+        success: bool,
+        installed: Vec<String>,
+    },
+    Remove {
+        success: bool,
+        removed: Vec<String>,
+    },
+    Aborted,
+}
+
+/// Status of a single package from `check-installed`.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PackageStatus {
+    pub name: String,
+    pub status: InstalledStatus,
+    /// Present when `status` is `Installed`.
+    pub version: Option<String>,
+    /// Whether the package is auto-installed (a dep) vs explicitly installed.
+    /// `None` if the package is not installed.
+    pub is_auto: Option<bool>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum InstalledStatus {
+    Installed,
+    Missing,
+}
+
+/// A single package action in an install plan.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PlannedAction {
+    pub name: String,
+    pub version: String,
+    /// Present for upgrades/downgrades.
+    pub old_version: Option<String>,
+    pub action: ActionKind,
+    /// Bytes to download.
+    pub download_size: u64,
+    /// Bytes on disk after install.
+    pub install_size: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ActionKind {
+    Install,
+    Upgrade,
+    Downgrade,
+    Reinstall,
+    Remove,
+}
+
+// ── Streaming events ──────────────────────────────────────────────────────
+
+/// A progress event emitted during a streaming command (install/remove).
+///
+/// Wire format: `{"phase":"download","event":"start","total_bytes":...}`
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "phase", rename_all = "kebab-case")]
+pub enum Event {
+    Download {
+        #[serde(flatten)]
+        inner: DownloadEvent,
+    },
+    Install {
+        #[serde(flatten)]
+        inner: InstallEvent,
+    },
+    Remove {
+        #[serde(flatten)]
+        inner: RemoveEvent,
+    },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "event", rename_all = "kebab-case")]
+pub enum DownloadEvent {
+    Start {
+        total_bytes: u64,
+        total_packages: u32,
+    },
+    Progress {
+        package: String,
+        bytes_done: u64,
+        bytes_total: u64,
+    },
+    ItemDone {
+        package: String,
+    },
+    Done,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "event", rename_all = "kebab-case")]
+pub enum InstallEvent {
+    Start {
+        total_packages: u32,
+    },
+    Action {
+        package: String,
+        action: String,
+        current: u32,
+        total: u32,
+        percent: Option<u32>,
+    },
+    ItemDone {
+        package: String,
+        current: u32,
+        total: u32,
+    },
+    Hook {
+        name: String,
+        current: u32,
+        total: u32,
+    },
+    Done,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "event", rename_all = "kebab-case")]
+pub enum RemoveEvent {
+    Start {
+        total_packages: u32,
+    },
+    Action {
+        package: String,
+        action: String,
+        current: u32,
+        total: u32,
+        percent: Option<u32>,
+    },
+    ItemDone {
+        package: String,
+        current: u32,
+        total: u32,
+    },
+    Done,
+}
+
+// ── Errors ────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ProtocolError {
+    pub code: ErrorCode,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ErrorCode {
+    /// Backend lacks root privileges. koca should re-launch with sudo.
+    NeedsElevation,
+    PackageNotFound,
+    DependencyConflict,
+    TransactionFailed,
+    DatabaseLocked,
+    Internal,
+}
+
+impl std::fmt::Display for ProtocolError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for ProtocolError {}


### PR DESCRIPTION
## Summary
- Repology-based cross-distro dependency resolution (`makedepends` + `depends`) with version constraint checking via `libversion`
- GPL-isolated ALPM backend binary communicating over Unix sockets (`koca-proto` crate)
- Ratatui inline TUI: resolve spinner, confirm screen with Y/n, download/install progress, build/package scrolling gutter, failure display
- `DynViewport` using `Viewport::Fixed` (inspired by OpenAI Codex patterns) to avoid DSR cursor position query issues
- No-sudo planning: resolve + plan without sudo, confirm, then sudo only for install
- DRY cleanup: `OutputType`/`BundleFormat` methods, `From<io::Error>` for `CliMultiError`, `spawn_line_reader` helper
- Ctrl+C handler restores terminal state when in raw mode
- Clippy-clean, `cargo fmt`'d

## Test plan
- [ ] `koca create test.koca` — full flow with makedepends (install, build, package)
- [ ] `koca create test.koca --noconfirm` — skips Y/n prompt
- [ ] `koca create test.koca --output-type deb` / `rpm` / default `all`
- [ ] Decline Y/n with `n` — exits gracefully, no error
- [ ] Ctrl+C during build/package — terminal restored cleanly
- [ ] Pipe output: `koca create test.koca 2>&1 | cat` — falls back to plain CLI
- [ ] Run near bottom of terminal (spam Enter first) — viewport scrolls to make room

🤖 Generated with [Claude Code](https://claude.com/claude-code)