### PR TITLE
ci: separate tag creation from publishing

### DIFF
--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -1,0 +1,19 @@
+name: Release Rust
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo publish --locked --package koca
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,24 +13,11 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  release-plz:
-    name: Release-plz
-    needs: create-pr
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: release-plz/action@v0.5
-        with:
-          command: release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
-  create-pr:
-    name: Create PR
+  # Creates/updates a release PR with version bumps (Cargo.toml, CHANGELOG.md)
+  # and non-Cargo version files (package.json, koca.koca). Runs on every push
+  # to main, no-op when there are no releasable changes.
+  create-release-pr:
+    name: Create release PR
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -72,3 +59,22 @@ jobs:
           git add npm/cli/package.json koca.koca
           git commit -m "chore: update non-cargo versions to $VERSION"
           git push origin "$HEAD_BRANCH"
+
+  # Detects merged release PRs and creates git tags + GitHub releases.
+  # Does NOT publish to any registry — all publishing is tag-triggered
+  # via separate release-* workflows.
+  release-tag:
+    name: Release tag
+    needs: create-release-pr
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,5 +76,5 @@ jobs:
         with:
           command: release
         env:
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,4 +1,5 @@
 [workspace]
+publish = false
 changelog_update = true
 git_release_enable = true
 git_tag_enable = true


### PR DESCRIPTION
## Summary
- Rename jobs: `create-pr` → `create-release-pr`, `release-plz` → `release-tag`
- Add `publish = false` to release-plz.toml so `release-tag` only creates git tags + GitHub releases, no crates.io publishing
- Add `release-rust.yml` — tag-triggered (`v*`) workflow that runs `cargo publish --package koca`
- All publishing is now tag-triggered, making it easy to add `release-npm`, `release-aur`, etc. later

## Architecture
```
push to main → create-release-pr (version bump PR)
                release-tag (git tag + GitHub release, after PR job)
tag v* created → release-rust (cargo publish)
                 release-npm (future)
                 release-aur (future)
```

## Test plan
- [ ] CI passes
- [ ] After merge, release workflow creates a release PR
- [ ] After release PR merge, `release-tag` creates a `v*` tag
- [ ] Tag triggers `release-rust` which publishes to crates.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)