### PR TITLE
fix: correct license and remove stale cargo install from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,6 @@ curl -fsSL https://go.koca.dev/install | bash
 #### GitHub Releases
 You can also download the latest pre-built binaries for your platform from the [GitHub releases](https://github.com/koca-build/koca/releases/) page.
 
-#### Via Cargo
-If you have Rust and Cargo installed, you can build and install Koca from source:
-
-```bash
-cargo install koca-cli
-```
-
 #### Via Docker
 You can also run Koca as a Docker container:
 
@@ -85,4 +78,4 @@ koca create your-app.koca --output-type rpm
 
 ## License
 
-Koca is released under the [FSL-1.1-MIT](LICENSE) license.
+Koca is released under the [MIT](LICENSE) license.


### PR DESCRIPTION
## Summary
- Fix license reference: FSL-1.1-MIT → MIT (was relicensed in b263f2b)
- Remove `cargo install koca-cli` section (crate no longer published)

🤖 Generated with [Claude Code](https://claude.com/claude-code)