### PR TITLE
feat: build dirs, output dirs, and build file auto-discovery

### DIFF
--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -32,8 +32,9 @@ impl OutputType {
 
 #[derive(Parser)]
 pub struct CreateArgs {
-    /// The path to the build file.
-    pub build_file: PathBuf,
+    /// The path to the build file. If omitted, searches for a single *.koca
+    /// file in the current directory, then in a `koca/` subdirectory.
+    pub build_file: Option<PathBuf>,
     /// The output file type.
     #[arg(long, value_enum, default_value_t = OutputType::All)]
     pub output_type: OutputType,

--- a/crates/cli/src/create.rs
+++ b/crates/cli/src/create.rs
@@ -39,7 +39,12 @@ pub async fn run(args: CreateArgs) -> CliMultiResult<()> {
 }
 
 async fn run_inner(args: &CreateArgs, ui: &mut dyn CreateUi) -> CliMultiResult<()> {
-    let mut build_file = BuildFile::parse_file(&args.build_file)
+    let build_file_path = match &args.build_file {
+        Some(p) => p.clone(),
+        None => crate::discover::find_build_file()?,
+    };
+
+    let mut build_file = BuildFile::parse_file(&build_file_path)
         .await
         .map_err(|errs| {
             CliMultiError(errs.into_iter().map(|err| CliError::Koca { err }).collect())
@@ -211,7 +216,7 @@ async fn run_inner(args: &CreateArgs, ui: &mut dyn CreateUi) -> CliMultiResult<(
         .arg(&exe)
         .arg("internal")
         .arg("package")
-        .arg(&args.build_file)
+        .arg(&build_file_path)
         .arg("--output-type")
         .arg(output_type_str)
         .stdout(std::process::Stdio::piped())
@@ -261,7 +266,10 @@ async fn run_inner(args: &CreateArgs, ui: &mut dyn CreateUi) -> CliMultiResult<(
     let mut output_files = Vec::new();
     for name in build_file.pkgnames() {
         for fmt in args.output_type.bundle_formats() {
-            output_files.push(format!("./{}", fmt.output_filename(name, &version, &arch)));
+            output_files.push(format!(
+                "koca-out/{}",
+                fmt.output_filename(name, &version, &arch)
+            ));
         }
     }
 

--- a/crates/cli/src/discover.rs
+++ b/crates/cli/src/discover.rs
@@ -1,0 +1,47 @@
+use std::path::PathBuf;
+
+use crate::error::CliMultiError;
+
+/// Find a single `.koca` build file in the current directory, falling back to
+/// a `koca/` subdirectory.
+pub fn find_build_file() -> Result<PathBuf, CliMultiError> {
+    if let Some(path) = find_single_koca_in(".")? {
+        return Ok(path);
+    }
+
+    if let Some(path) = find_single_koca_in("koca")? {
+        return Ok(path);
+    }
+
+    Err(std::io::Error::other(
+        "no .koca file found in current directory or koca/ subdirectory",
+    ))?
+}
+
+/// Return the single `.koca` file in `dir`, or `None` if the directory doesn't
+/// exist or contains no `.koca` files. Errors if multiple `.koca` files are found.
+fn find_single_koca_in(dir: &str) -> Result<Option<PathBuf>, CliMultiError> {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e)?,
+    };
+
+    let mut found: Option<PathBuf> = None;
+
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+
+        if path.extension().is_some_and(|ext| ext == "koca") && path.is_file() {
+            if found.is_some() {
+                Err(std::io::Error::other(format!(
+                    "multiple .koca files found in {dir}/ — specify one explicitly",
+                )))?;
+            }
+            found = Some(path);
+        }
+    }
+
+    Ok(found)
+}

--- a/crates/cli/src/internal/package.rs
+++ b/crates/cli/src/internal/package.rs
@@ -25,6 +25,8 @@ pub async fn run(args: PackageArgs) -> CliMultiResult<()> {
         args.package.clone()
     };
 
+    std::fs::create_dir_all("koca-out").map_err(|err| CliError::Io { err })?;
+
     for pkg_name in &pkg_names {
         // Run the package function.
         let func_label = if build_file.pkgnames().len() > 1 {
@@ -50,17 +52,15 @@ pub async fn run(args: PackageArgs) -> CliMultiResult<()> {
             let arch = build_file.arch()[0].clone();
             let file_name =
                 bundle_format.output_filename(pkg_name, &build_file.version().to_string(), &arch);
+            let out_path = Path::new("koca-out").join(&file_name);
 
             zolt::infoln!(
                 "Creating package into {}{}...",
-                "./".blue().bold(),
+                "koca-out/".blue().bold(),
                 file_name.blue().bold()
             );
 
-            if let Err(err) = build_file
-                .bundle(pkg_name, bundle_format, Path::new(&file_name))
-                .await
-            {
+            if let Err(err) = build_file.bundle(pkg_name, bundle_format, &out_path).await {
                 return Err(CliError::Koca { err }.into());
             }
         }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2,6 +2,7 @@
 
 mod cli;
 mod create;
+mod discover;
 mod error;
 mod internal;
 mod tui;

--- a/crates/koca/src/file/mod.rs
+++ b/crates/koca/src/file/mod.rs
@@ -834,10 +834,10 @@ pub mod funcs {
 /// The directories used by Koca.
 mod dirs {
     /// The directory where Koca stores source files.
-    pub const SRC: &str = "koca/src";
+    pub const SRC: &str = "koca-build/src";
 
     /// Return the package directory for a named sub-package.
     pub fn pkg_for(name: &str) -> String {
-        format!("koca/pkg/{name}")
+        format!("koca-build/pkg/{name}")
     }
 }


### PR DESCRIPTION
## Summary
- Rename build working dirs from `koca/` to `koca-build/` (frees `koca/` for package subdirectories)
- Output artifacts (.deb/.rpm) to `koca-out/` instead of `./`
- Auto-discover `.koca` build file when no path is given (checks CWD then `koca/` subdir)

## Test plan
- [ ] `koca create` with no args in a dir with a single `.koca` file
- [ ] `koca create` with no args when `.koca` file is in `koca/` subdir
- [ ] `koca create` errors on zero or multiple `.koca` files
- [ ] Build artifacts land in `koca-build/`, output in `koca-out/`
- [ ] Explicit `koca create foo.koca` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)