### PR TITLE
feat: add deb/rpm packaging for `amd64`/`arm64` architectures

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,7 +1,7 @@
 name: Release Tag
 
 # Detects merged release PRs and creates git tags + draft GitHub releases,
-# builds multi-arch binaries, then publishes the release with assets attached.
+# builds multi-arch binaries and deb/rpm packages, then publishes the release.
 
 on:
   push:
@@ -43,33 +43,37 @@ jobs:
       matrix:
         include:
           - os: ubuntu-24.04
-            target: x86_64-unknown-linux-musl
             arch: x86_64
           - os: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-musl
             arch: aarch64
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
-
-      - name: Install musl toolchain
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y musl-tools
-
       - uses: Swatinem/rust-cache@v2
         with:
-          key: release-${{ matrix.target }}
+          key: release-${{ matrix.arch }}
 
-      - name: Build static binary
-        run: cargo build --locked --release --target ${{ matrix.target }} --bin koca
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools fakeroot
+
+      - name: Build packages
+        run: cargo run --locked --bin koca -- create koca.koca --output-type all --noconfirm
+
+      - name: Collect binary
+        run: cp "koca-build/src/koca/target/$(uname -m)-unknown-linux-musl/release/koca" "koca-${{ matrix.arch }}"
 
       - uses: actions/upload-artifact@v4
         with:
           name: binary-${{ matrix.arch }}
-          path: target/${{ matrix.target }}/release/koca
+          path: koca-${{ matrix.arch }}
+          if-no-files-found: error
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: packages-${{ matrix.arch }}
+          path: koca-out/*
           if-no-files-found: error
 
   publish-release:
@@ -82,6 +86,10 @@ jobs:
         with:
           pattern: binary-*
 
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: packages-*
+
       - name: Upload assets and publish
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -91,7 +99,7 @@ jobs:
           set -euo pipefail
           for dir in binary-*; do
             arch="${dir#binary-}"
-            mv "$dir/koca" "koca-${arch}"
+            mv "$dir/koca-${arch}" "koca-${arch}"
           done
-          gh release upload "$TAG" koca-*
+          gh release upload "$TAG" koca-* packages-*/*
           gh release edit "$TAG" --draft=false

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -101,5 +101,5 @@ jobs:
             arch="${dir#binary-}"
             mv "$dir/koca-${arch}" "koca-${arch}"
           done
-          gh release upload "$TAG" koca-* packages-*/*
+          gh release upload "$TAG" koca-x86_64 koca-aarch64 packages-*/*
           gh release edit "$TAG" --draft=false

--- a/install.sh
+++ b/install.sh
@@ -105,11 +105,8 @@ main() {
       local koca_deb="${tmpdir}/koca.deb"
       download "${base_url}/koca_${version}-1_${arch_deb}.deb" "$koca_deb"
 
-      local backend_deb="${tmpdir}/koca-backend-apt.deb"
-      download "${base_url}/koca-backend-apt_${version}-1_${arch_deb}.deb" "$backend_deb"
-
-      info "installing via dpkg..."
-      sudo dpkg -i "$koca_deb" "$backend_deb"
+      info "installing via apt..."
+      sudo apt install -y "$koca_deb"
       ;;
     rpm)
       info "method   rpm package"
@@ -117,16 +114,13 @@ main() {
       local koca_rpm="${tmpdir}/koca.rpm"
       download "${base_url}/koca_${version}-1_${arch}.rpm" "$koca_rpm"
 
-      local backend_rpm="${tmpdir}/koca-backend-apt.rpm"
-      download "${base_url}/koca-backend-apt_${version}-1_${arch}.rpm" "$backend_rpm"
-
       info "installing via rpm..."
       if command -v dnf &>/dev/null; then
-        sudo dnf install -y "$koca_rpm" "$backend_rpm"
+        sudo dnf install -y "$koca_rpm"
       elif command -v yum &>/dev/null; then
-        sudo yum install -y "$koca_rpm" "$backend_rpm"
+        sudo yum install -y "$koca_rpm"
       else
-        sudo rpm -i "$koca_rpm" "$backend_rpm"
+        sudo rpm -i "$koca_rpm"
       fi
       ;;
     binary)

--- a/koca.koca
+++ b/koca.koca
@@ -15,10 +15,13 @@ build() {
     fi
 
     cd "${pkgname}/"
-    cargo build --release --bin koca
+    target="$(uname -m)-unknown-linux-musl"
+    rustup target add "${target}"
+    cargo build --release --locked --target "${target}" --bin koca
 }
 
 package() {
     cd "${pkgname}/"
-    install -Dm 755 "target/release/koca" "${pkgdir}/usr/bin/koca"
+    target="$(uname -m)-unknown-linux-musl"
+    install -Dm 755 "target/${target}/release/koca" "${pkgdir}/usr/bin/koca"
 }


### PR DESCRIPTION
## Summary
- Use `koca create` for the release build instead of raw `cargo build`, producing deb/rpm packages alongside the static binary
- Update `koca.koca` to build with musl for static binaries
- Remove dead `koca-backend-apt` references from installer, switch deb install from `dpkg -i` to `apt install`

## Test plan
- [ ] Verify CI workflow syntax is valid
- [ ] Confirm release produces: `koca-x86_64`, `koca-aarch64`, deb + rpm for both architectures
- [ ] Test installer script on deb and rpm systems

🤖 Generated with [Claude Code](https://claude.com/claude-code)