### PR TITLE
feat: add license, backup, and maintainer support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ target/
 /koca/
 *.deb
 *.rpm
+koca-build/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,6 +583,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "charset"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f927b07c74ba84c7e5fe4db2baeb3e996ab2688992e39ac68ce3220a677c7e"
+dependencies = [
+ "base64",
+ "encoding_rs",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,6 +948,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "dbl"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1197,6 +1213,15 @@ dependencies = [
  "sec1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -2087,6 +2112,7 @@ dependencies = [
  "interprocess",
  "itertools",
  "libversion",
+ "mailparse",
  "md-5",
  "nix 0.29.0",
  "repology",
@@ -2097,6 +2123,7 @@ dependencies = [
  "serde_json",
  "sha1",
  "sha2",
+ "spdx",
  "tar",
  "tempfile",
  "thiserror 2.0.18",
@@ -2250,6 +2277,17 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "mailparse"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60819a97ddcb831a5614eb3b0174f3620e793e97e09195a395bfa948fd68ed2f"
+dependencies = [
+ "charset",
+ "data-encoding",
+ "quoted_printable",
+]
 
 [[package]]
 name = "md-5"
@@ -3006,6 +3044,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quoted_printable"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478e0585659a122aa407eb7e3c0e1fa51b1d8a870038bd29f0cf4a8551eea972"
+
+[[package]]
 name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3246,9 +3290,9 @@ dependencies = [
 
 [[package]]
 name = "rfpm"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17435ee7f2fa993b31053ac08c8b3618c045490d90603323cbbf32cf725a399e"
+checksum = "67145930aa679ad460fa13bd2e36f95b4ba648bf3a0693b10d6c7d4f08dbe07f"
 dependencies = [
  "ar",
  "flate2",
@@ -3717,6 +3761,15 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spdx"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8da593e30beb790fc9424502eb898320b44e5eb30367dbda1c1edde8e2f32d7"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,9 @@ directories = "6.0.0"
 flate2 = "1.1.2"
 git2 = { version = "0.20", features = ["vendored-libgit2", "vendored-openssl"] }
 koca = { path = "crates/koca", version = "0.6.1" }
-rfpm = "0.2.0"
+rfpm = "0.2.1"
+spdx = "0.13.4"
+mailparse = "0.16.1"
 semver = "1.0.26"
 thiserror = "2.0.12"
 tar = "0.4.44"

--- a/crates/koca/Cargo.toml
+++ b/crates/koca/Cargo.toml
@@ -22,7 +22,9 @@ md-5 = { workspace = true }
 nix = { workspace = true }
 repology = { workspace = true }
 reqwest = { workspace = true }
+mailparse = { workspace = true }
 rfpm = { workspace = true }
+spdx = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/koca/src/error.rs
+++ b/crates/koca/src/error.rs
@@ -40,6 +40,15 @@ pub enum KocaParserError {
     /// An invalid string was specified for an architecture.
     #[error("'{0}' is not a valid architecture")]
     InvalidArch(String),
+    /// An invalid SPDX license expression.
+    #[error("'{0}' is not a valid SPDX license expression: {1}")]
+    InvalidLicense(String, String),
+    /// A backup path that isn't absolute.
+    #[error("backup path '{0}' must be an absolute path (start with '/')")]
+    InvalidBackupPath(String),
+    /// An invalid maintainer string.
+    #[error("'{0}' is not a valid maintainer (expected 'Name <email>'): {1}")]
+    InvalidMaintainer(String, String),
     /// A required variable was not defined.
     #[error("the variable '{0}' was not defined")]
     MissingRequiredVariable(String),

--- a/crates/koca/src/file/mod.rs
+++ b/crates/koca/src/file/mod.rs
@@ -138,6 +138,12 @@ pub struct BuildFile {
     var_makedepends: Vec<crate::dep::DepConstraint>,
     /// The package's source entries, keyed by arch (None = base `source=()`).
     var_source: HashMap<Option<Arch>, Vec<crate::source::Source>>,
+    /// The package's SPDX license expression (optional).
+    var_license: Option<String>,
+    /// Paths to mark as config files in the output package (optional).
+    var_backup: Vec<String>,
+    /// The package's maintainer from `# Maintainer:` comment (optional).
+    var_maintainer: Option<String>,
     /// The package's `build` function (optional).
     build_func: Option<FunctionDefinition>,
     /// Package functions keyed by package name.
@@ -335,17 +341,72 @@ impl BuildFile {
         Ok(archs)
     }
 
+    fn parse_license(value: &DeclValue) -> KocaResult<String> {
+        let license = Self::get_decl_string(vars::LICENSE, value)?;
+        spdx::Expression::parse(&license)
+            .map_err(|e| KocaParserError::InvalidLicense(license.clone(), e.to_string()))?;
+        Ok(license)
+    }
+
+    fn parse_backup(value: &DeclValue) -> KocaMultiResult<Vec<String>> {
+        let paths = Self::parse_string_array(vars::BACKUP, value)?;
+        let mut errs = vec![];
+        for path in &paths {
+            if !path.starts_with('/') {
+                errs.push(KocaParserError::InvalidBackupPath(path.clone()).into());
+            }
+        }
+        if !errs.is_empty() {
+            return Err(errs);
+        }
+        Ok(paths)
+    }
+
+    /// Extract and validate the `# Maintainer:` comment from raw file text.
+    ///
+    /// Returns `Ok(Some(maintainer))` if found and valid, `Ok(None)` if absent,
+    /// or `Err` if present but invalid.
+    fn parse_maintainer(raw: &str) -> KocaResult<Option<String>> {
+        let Some(maintainer_str) = raw.lines().find_map(|line| {
+            line.trim()
+                .strip_prefix("# Maintainer:")
+                .map(|rest| rest.trim().to_string())
+        }) else {
+            return Ok(None);
+        };
+
+        match mailparse::addrparse(&maintainer_str) {
+            Ok(ref addr_list) if addr_list.count_addrs() == 1 => Ok(Some(maintainer_str)),
+            Ok(_) => Err(KocaParserError::InvalidMaintainer(
+                maintainer_str,
+                "expected exactly one address".into(),
+            )
+            .into()),
+            Err(e) => Err(KocaParserError::InvalidMaintainer(maintainer_str, e.to_string()).into()),
+        }
+    }
+
     /// Parse a Koca build script from the reader.
     ///
     /// Returns a [`KocaError::Parser`] error if the input is an invalid script.
-    pub async fn parse<R: Read>(reader: R) -> KocaMultiResult<Self> {
-        // Create the shell.
+    pub async fn parse<R: Read>(mut reader: R) -> KocaMultiResult<Self> {
+        // Read raw text to extract comments before brush strips them.
+        let mut raw = String::new();
+        reader
+            .read_to_string(&mut raw)
+            .map_err(|e| vec![KocaError::from(e)])?;
+
+        // Extract and validate # Maintainer: (brush strips comments).
+        let opt_maintainer = Self::parse_maintainer(&raw);
+
+        // Pass text to brush via Cursor.
+        let cursor = std::io::Cursor::new(raw.as_bytes());
         let create_options = Self::create_options();
         let shell = Shell::new(create_options)
             .await
             .expect("shell options should be valid");
         let program = shell
-            .parse(reader)
+            .parse(cursor)
             .map_err(|err| vec![KocaParserError::from(err).into()])?;
         let decl_items = parser::get_decls(&program).map_err(|err| vec![err])?;
 
@@ -361,12 +422,23 @@ impl BuildFile {
         let mut opt_depends: Vec<crate::dep::DepConstraint> = vec![];
         let mut opt_makedepends: Vec<crate::dep::DepConstraint> = vec![];
         let mut opt_source: HashMap<Option<Arch>, Vec<crate::source::Source>> = HashMap::new();
+        let mut opt_license: Option<String> = None;
+        let mut opt_backup: Vec<String> = vec![];
 
         let mut opt_build_func: Option<FunctionDefinition> = None;
         let mut single_package_func: Option<FunctionDefinition> = None;
         let mut split_package_funcs: HashMap<String, FunctionDefinition> = HashMap::new();
 
         let mut errs = vec![];
+
+        // Resolve maintainer from pre-brush comment extraction.
+        let opt_maintainer = match opt_maintainer {
+            Ok(m) => m,
+            Err(err) => {
+                errs.push(err);
+                None
+            }
+        };
 
         // Extract variables.
         for (key, value) in &decl_items.vars {
@@ -412,6 +484,14 @@ impl BuildFile {
                 vars::MAKEDEPENDS => match Self::parse_dep_array(vars::MAKEDEPENDS, value) {
                     Ok(makedepends) => opt_makedepends = makedepends,
                     Err(dep_errs) => errs.extend(dep_errs),
+                },
+                vars::LICENSE => match Self::parse_license(value) {
+                    Ok(license) => opt_license = Some(license),
+                    Err(err) => errs.push(err),
+                },
+                vars::BACKUP => match Self::parse_backup(value) {
+                    Ok(paths) => opt_backup = paths,
+                    Err(backup_errs) => errs.extend(backup_errs),
                 },
                 // source and source_* are deferred to pass 2 (need variable expansion).
                 _ if key == vars::SOURCE || key.starts_with("source_") => continue,
@@ -604,6 +684,9 @@ impl BuildFile {
             var_depends: opt_depends,
             var_makedepends: opt_makedepends,
             var_source: opt_source,
+            var_license: opt_license,
+            var_backup: opt_backup,
+            var_maintainer: opt_maintainer,
             build_func: opt_build_func,
             package_funcs,
         })
@@ -827,13 +910,14 @@ impl BuildFile {
             .map(|r| r.to_string())
             .unwrap_or_else(|| "1".to_string());
         pkg.epoch = self.var_version.epoch;
-        // TODO: Get maintainer from build file (https://github.com/reubeno/brush/issues/513).
-        pkg.maintainer = Some("Foo Bar <foobar@example.com>".to_string());
-        // TODO: Get license from build file.
-        pkg.license = Some("CONTACT-PUBLISHER".to_string());
+        pkg.maintainer = self.var_maintainer.clone();
+        pkg.license = self.var_license.clone();
         pkg.depends = self.var_depends.iter().map(|d| d.to_string()).collect();
 
         // Walk the package directory and add files. Ownership defaults to root:root.
+        let backup_set: std::collections::HashSet<&str> =
+            self.var_backup.iter().map(|p| p.as_str()).collect();
+
         for res_entry in WalkDir::new(&pkg_dir) {
             let entry = res_entry.map_err(|e| std::io::Error::other(e.to_string()))?;
             if entry.file_type().is_dir() {
@@ -852,15 +936,18 @@ impl BuildFile {
                 .expect("file metadata should always be readable");
             let mode = metadata.mode() & 0o7777;
 
+            let dest = format!("/{}", dst_path.display());
             let file = File::open(&src_path)?;
-            pkg.add_file_with(
-                format!("/{}", dst_path.display()),
-                file,
-                rfpm::FileOptions {
-                    mode,
-                    ..Default::default()
-                },
-            );
+            let opts = rfpm::FileOptions {
+                mode,
+                ..Default::default()
+            };
+
+            if backup_set.contains(dest.as_str()) {
+                pkg.add_config_with(dest, file, opts);
+            } else {
+                pkg.add_file_with(dest, file, opts);
+            }
         }
 
         let mut out = File::create(out_file)?;
@@ -921,6 +1008,21 @@ impl BuildFile {
         &self.var_makedepends
     }
 
+    /// Get the package's SPDX license expression.
+    pub fn license(&self) -> Option<&str> {
+        self.var_license.as_deref()
+    }
+
+    /// Get the package's backup/conffiles paths.
+    pub fn backup(&self) -> &[String] {
+        &self.var_backup
+    }
+
+    /// Get the package's maintainer.
+    pub fn maintainer(&self) -> Option<&str> {
+        self.var_maintainer.as_deref()
+    }
+
     /// Get the source entries for a given target arch.
     ///
     /// Returns `source_$ARCH` if defined, otherwise falls back to `source`.
@@ -974,6 +1076,8 @@ pub mod vars {
     pub const PKGDESC: &str = "pkgdesc";
     pub const DEPENDS: &str = "depends";
     pub const MAKEDEPENDS: &str = "makedepends";
+    pub const LICENSE: &str = "license";
+    pub const BACKUP: &str = "backup";
     pub const SOURCE: &str = "source";
 }
 


### PR DESCRIPTION
## Summary
- **`license` variable**: SPDX expression string, validated at parse time via `spdx` crate. Used in RPM/Arch metadata; metadata-only for deb.
- **`backup` variable**: Array of absolute paths marked as config files. Generates `conffiles` in deb, `config(noreplace)` in RPM, `backup` in Arch.
- **`# Maintainer:` comment**: Extracted from raw file text before brush strips comments. Validated as `Name <email>` via `mailparse` crate.

All three were previously hardcoded placeholders. rfpm already supported them; this wires them through koca's parser and bundler.

Depends on rfpm 0.2.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)