### PR TITLE
chore: bump rfpm to 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3290,9 +3290,9 @@ dependencies = [
 
 [[package]]
 name = "rfpm"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67145930aa679ad460fa13bd2e36f95b4ba648bf3a0693b10d6c7d4f08dbe07f"
+checksum = "5992fae56c362957d33468ba04c3aced001c9150edc453024d5f509fcfb58620"
 dependencies = [
  "ar",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ directories = "6.0.0"
 flate2 = "1.1.2"
 git2 = { version = "0.20", features = ["vendored-libgit2", "vendored-openssl"] }
 koca = { path = "crates/koca", version = "0.7.0" }
-rfpm = "0.2.1"
+rfpm = "0.2.2"
 spdx = "0.13.4"
 mailparse = "0.16.1"
 semver = "1.0.26"


### PR DESCRIPTION
Bumps `rfpm` 0.2.1 → 0.2.2, pulling in the deb parent-directory fix ([rfpm#8](https://github.com/koca-build/rfpm/pull/8)): `data.tar` now includes a directory entry for every parent path, so packages that install into directories not already present on the target (e.g. `/usr/share/...`) unpack instead of failing with `unable to create '...dpkg-new': No such file or directory`.