### PR TITLE
ci: cache Rust deps in release jobs

### DIFF
--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -14,6 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
       - run: cargo publish --locked --package koca
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
       - id: release-plz
         uses: release-plz/action@v0.5
         with:


### PR DESCRIPTION
The release-plz `release` job (`release-tag.yml`) and the crates.io publish job (`release-rust.yml`) were the only compiling Rust jobs without `Swatinem/rust-cache@v2`, so every release cold-builds all dependencies. Adds the same cache step `clippy`/`test`/`build` already use.

Reliable win is the restored crates.io registry/index. Note: `cargo publish`'s verification build uses an isolated `target/package/.../target`, so its compile isn't fully cached — if release time is still dominated by that, the bigger lever is release-plz `publish_no_verify` (safe, since CI already builds + tests the same commit). Happy to do that as a follow-up.