### PR TITLE
ci: use sccache for all Rust compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ on:
 permissions:
   contents: read
 
+env:
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
+  CARGO_INCREMENTAL: "0"
+
 jobs:
   fmt:
     name: cargo fmt
@@ -18,6 +23,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - run: cargo fmt --all --check
 
   clippy:
@@ -28,7 +34,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - run: cargo clippy --all-targets -- -Dwarnings
 
   test:
@@ -37,5 +43,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - run: cargo test

--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -7,6 +7,11 @@ on:
 permissions:
   contents: read
 
+env:
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
+  CARGO_INCREMENTAL: "0"
+
 jobs:
   publish:
     name: Publish to crates.io
@@ -14,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - run: cargo publish --locked --package koca
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -14,6 +14,11 @@ concurrency:
   group: release-tag-${{ github.ref }}
   cancel-in-progress: false
 
+env:
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
+  CARGO_INCREMENTAL: "0"
+
 jobs:
   release-tag:
     name: Release tag
@@ -26,7 +31,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - id: release-plz
         uses: release-plz/action@v0.5
         with:
@@ -50,9 +55,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: release-${{ matrix.arch }}
+      - uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Install build dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,11 @@ concurrency:
   group: release-plz-${{ github.ref }}
   cancel-in-progress: false
 
+env:
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
+  CARGO_INCREMENTAL: "0"
+
 jobs:
   # Creates/updates a release PR with version bumps (Cargo.toml, CHANGELOG.md)
   # and non-Cargo version files (package.json, koca.koca). Runs on every push
@@ -24,7 +29,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - id: release-plz
         uses: release-plz/action@v0.5
         with:


### PR DESCRIPTION
Replaces `Swatinem/rust-cache` with sccache (GHA backend) across every Rust job.

The release build compiles koca for musl inside a nested `koca-build/src/koca` clone, which the workspace `./target` cache never covered — so it cold-compiled every release. sccache caches compilation by content regardless of where the build runs, warming that inner build (and the crates.io publish verify build) too.

Env (`SCCACHE_GHA_ENABLED`, `RUSTC_WRAPPER=sccache`, `CARGO_INCREMENTAL=0`) is set at the workflow level; the action is added to every Rust job. `publish-release` runs no cargo, so it has no sccache step.