### PR TITLE
feat: preserve symlinks in package payloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1599,6 +1599,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2173,6 +2179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a631d2b24be269775ba8f7789a6afa1ac228346a20c9e87dbbbe4975a79fd764"
 dependencies = [
  "liblzma-sys",
+ "num_cpus",
 ]
 
 [[package]]
@@ -2500,6 +2507,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -3290,9 +3307,9 @@ dependencies = [
 
 [[package]]
 name = "rfpm"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5992fae56c362957d33468ba04c3aced001c9150edc453024d5f509fcfb58620"
+checksum = "4c8974d6ed67a9edb31401df7484d03800530c41502fa86d8d1c4a610d94f314"
 dependencies = [
  "ar",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ directories = "6.0.0"
 flate2 = "1.1.2"
 git2 = { version = "0.20", features = ["vendored-libgit2", "vendored-openssl"] }
 koca = { path = "crates/koca", version = "0.7.1" }
-rfpm = "0.2.2"
+rfpm = "0.2.4"
 spdx = "0.13.4"
 mailparse = "0.16.1"
 semver = "1.0.26"

--- a/crates/koca/src/file/mod.rs
+++ b/crates/koca/src/file/mod.rs
@@ -918,35 +918,26 @@ impl BuildFile {
         let backup_set: std::collections::HashSet<&str> =
             self.var_backup.iter().map(|p| p.as_str()).collect();
 
-        for res_entry in WalkDir::new(&pkg_dir) {
-            let entry = res_entry.map_err(|e| std::io::Error::other(e.to_string()))?;
-            if entry.file_type().is_dir() {
-                continue;
-            }
-
-            let src_path =
-                path::absolute(entry.path()).expect("getting absolute path should always succeed");
-            let dst_path = entry
-                .path()
-                .strip_prefix(&pkg_dir)
-                .expect("pkgdir strip should always succeed");
-
-            let metadata = entry
-                .metadata()
-                .expect("file metadata should always be readable");
-            let mode = metadata.mode() & 0o7777;
-
-            let dest = format!("/{}", dst_path.display());
-            let file = File::open(&src_path)?;
-            let opts = rfpm::FileOptions {
-                mode,
-                ..Default::default()
-            };
-
-            if backup_set.contains(dest.as_str()) {
-                pkg.add_config_with(dest, file, opts);
-            } else {
-                pkg.add_file_with(dest, file, opts);
+        for entry in collect_pkg_entries(Path::new(&pkg_dir), &backup_set)? {
+            match entry {
+                PkgEntry::Symlink { src, target } => pkg.add_symlink(src, target),
+                PkgEntry::File {
+                    dest,
+                    src,
+                    mode,
+                    config,
+                } => {
+                    let file = File::open(&src)?;
+                    let opts = rfpm::FileOptions {
+                        mode,
+                        ..Default::default()
+                    };
+                    if config {
+                        pkg.add_config_with(dest, file, opts);
+                    } else {
+                        pkg.add_file_with(dest, file, opts);
+                    }
+                }
             }
         }
 
@@ -1097,5 +1088,126 @@ mod dirs {
     /// Return the package directory for a named sub-package.
     pub fn pkg_for(name: &str) -> String {
         format!("koca-build/pkg/{name}")
+    }
+}
+
+/// A package payload entry discovered by walking a built `$pkgdir`.
+enum PkgEntry {
+    /// A regular file to copy from `src` into the package at `dest`.
+    File {
+        dest: String,
+        src: path::PathBuf,
+        mode: u32,
+        config: bool,
+    },
+    /// A symlink at `src` pointing to `target`, stored verbatim (not followed).
+    Symlink { src: String, target: String },
+}
+
+/// Walk a built package directory into a flat list of payload entries.
+///
+/// Symlinks are recorded as links (never dereferenced) so they survive into the
+/// package; everything else is a file, marked `config` when listed in `backup`.
+fn collect_pkg_entries(
+    pkg_dir: &Path,
+    backup_set: &std::collections::HashSet<&str>,
+) -> KocaResult<Vec<PkgEntry>> {
+    let mut entries = Vec::new();
+    for res_entry in WalkDir::new(pkg_dir) {
+        let entry = res_entry.map_err(|e| std::io::Error::other(e.to_string()))?;
+        let file_type = entry.file_type();
+        if file_type.is_dir() {
+            continue;
+        }
+
+        let dst_path = entry
+            .path()
+            .strip_prefix(pkg_dir)
+            .expect("pkgdir strip should always succeed");
+        let dest = format!("/{}", dst_path.display());
+
+        if file_type.is_symlink() {
+            // WalkDir does not follow symlinks, so read_link yields the raw
+            // target; opening it would dereference (and fail on absolute or
+            // dangling targets).
+            let target = fs::read_link(entry.path())?;
+            entries.push(PkgEntry::Symlink {
+                src: dest,
+                target: target.to_string_lossy().into_owned(),
+            });
+            continue;
+        }
+
+        let src =
+            path::absolute(entry.path()).expect("getting absolute path should always succeed");
+        let mode = entry
+            .metadata()
+            .expect("file metadata should always be readable")
+            .mode()
+            & 0o7777;
+        let config = backup_set.contains(dest.as_str());
+        entries.push(PkgEntry::File {
+            dest,
+            src,
+            mode,
+            config,
+        });
+    }
+    Ok(entries)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{collect_pkg_entries, PkgEntry};
+    use std::collections::HashSet;
+
+    #[test]
+    fn collects_symlinks_as_links_not_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin = dir.path().join("usr/bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        std::fs::write(bin.join("foo"), b"payload").unwrap();
+        // Absolute target that does not exist on the host — opening it would fail.
+        std::os::unix::fs::symlink("/usr/bin/foo", bin.join("bar")).unwrap();
+
+        let backup = HashSet::new();
+        let entries = collect_pkg_entries(dir.path(), &backup).unwrap();
+
+        let target = entries.iter().find_map(|e| match e {
+            PkgEntry::Symlink { src, target } if src == "/usr/bin/bar" => Some(target.clone()),
+            _ => None,
+        });
+        assert_eq!(
+            target.as_deref(),
+            Some("/usr/bin/foo"),
+            "symlink recorded as a link with its raw target"
+        );
+
+        let foo_is_file = entries
+            .iter()
+            .any(|e| matches!(e, PkgEntry::File { dest, .. } if dest == "/usr/bin/foo"));
+        assert!(foo_is_file, "regular file recorded as a file");
+
+        let bar_as_file = entries
+            .iter()
+            .any(|e| matches!(e, PkgEntry::File { dest, .. } if dest == "/usr/bin/bar"));
+        assert!(!bar_as_file, "symlink not dereferenced into a file");
+    }
+
+    #[test]
+    fn marks_backup_paths_as_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let etc = dir.path().join("etc");
+        std::fs::create_dir_all(&etc).unwrap();
+        std::fs::write(etc.join("app.conf"), b"x").unwrap();
+
+        let backup: HashSet<&str> = ["/etc/app.conf"].into_iter().collect();
+        let entries = collect_pkg_entries(dir.path(), &backup).unwrap();
+
+        let config = entries.iter().find_map(|e| match e {
+            PkgEntry::File { dest, config, .. } if dest == "/etc/app.conf" => Some(*config),
+            _ => None,
+        });
+        assert_eq!(config, Some(true), "backup path marked as config");
     }
 }


### PR DESCRIPTION
`bundle()` walked `$pkgdir` and `File::open`d every non-dir entry as a regular file — so symlinks were silently dereferenced into file copies, and an absolute/dangling target (e.g. `/usr/bin/code -> /usr/share/code/bin/code`, created before its target exists) failed the whole build with `No such file or directory`.

Split the walk into a typed `collect_pkg_entries` step: symlinks are recorded via `read_link` (never followed) and emitted with rfpm's `add_symlink`; everything else stays a file. The pure walk is unit-tested (symlink-not-dereferenced, backup→config).

Also bumps `rfpm` to 0.2.4 (multithreaded xz + long deb paths), which this needs end-to-end.

Verified by building a real VS Code `code` deb: `usr/bin/code` is a symlink to `/usr/share/code/bin/code`, setuid `chrome-sandbox` preserved, 148-byte paths intact, `data.tar.xz` passes `xz -t`.