### PR TITLE
ci: replace sccache with Swatinem/rust-cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,10 @@ permissions:
   contents: read
 
 env:
-  SCCACHE_DIR: ${{ github.workspace }}/.sccache
-  RUSTC_WRAPPER: "sccache"
+  # Standardized target dir across all koca workflows; matches the path
+  # Swatinem/rust-cache globs (<workspace>/target) by default. See
+  # release-tag.yml for why this also matters for koca's nested build.
+  CARGO_TARGET_DIR: ${{ github.workspace }}/target
   CARGO_INCREMENTAL: "0"
 
 jobs:
@@ -23,7 +25,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
-      - uses: mozilla-actions/sccache-action@v0.0.10
       - run: cargo fmt --all --check
 
   clippy:
@@ -34,14 +35,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/.sccache
-          key: sccache-clippy-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/Cargo.lock') }}-${{ github.run_id }}
-          restore-keys: |
-            sccache-clippy-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/Cargo.lock') }}-
-            sccache-clippy-${{ runner.os }}-${{ runner.arch }}-
-      - uses: mozilla-actions/sccache-action@v0.0.10
+      - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-targets -- -Dwarnings
 
   test:
@@ -50,12 +44,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/.sccache
-          key: sccache-test-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/Cargo.lock') }}-${{ github.run_id }}
-          restore-keys: |
-            sccache-test-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/Cargo.lock') }}-
-            sccache-test-${{ runner.os }}-${{ runner.arch }}-
-      - uses: mozilla-actions/sccache-action@v0.0.10
+      - uses: Swatinem/rust-cache@v2
       - run: cargo test

--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -8,8 +8,10 @@ permissions:
   contents: read
 
 env:
-  SCCACHE_DIR: ${{ github.workspace }}/.sccache
-  RUSTC_WRAPPER: "sccache"
+  # Standardized target dir across all koca workflows; matches the path
+  # Swatinem/rust-cache globs (<workspace>/target) by default. See
+  # release-tag.yml for why this also matters for koca's nested build.
+  CARGO_TARGET_DIR: ${{ github.workspace }}/target
   CARGO_INCREMENTAL: "0"
 
 jobs:
@@ -19,14 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/.sccache
-          key: sccache-publish-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/Cargo.lock') }}-${{ github.run_id }}
-          restore-keys: |
-            sccache-publish-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/Cargo.lock') }}-
-            sccache-publish-${{ runner.os }}-${{ runner.arch }}-
-      - uses: mozilla-actions/sccache-action@v0.0.10
+      - uses: Swatinem/rust-cache@v2
       - run: cargo publish --locked --package koca
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -15,8 +15,12 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  SCCACHE_DIR: ${{ github.workspace }}/.sccache
-  RUSTC_WRAPPER: "sccache"
+  # Pin a single target dir for every cargo invocation. koca shells out to
+  # `cargo build` for its own package, and since it inherits this env var that
+  # nested build lands here too instead of koca-build/src/koca/target. One
+  # shared tree means deps compile once and Swatinem/rust-cache (which globs
+  # <workspace>/target by default) actually caches the package build.
+  CARGO_TARGET_DIR: ${{ github.workspace }}/target
   CARGO_INCREMENTAL: "0"
 
 jobs:
@@ -31,7 +35,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@stable
-      - uses: mozilla-actions/sccache-action@v0.0.10
+      - uses: Swatinem/rust-cache@v2
       - id: release-plz
         uses: release-plz/action@v0.5
         with:
@@ -55,14 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/.sccache
-          key: sccache-build-${{ matrix.arch }}-${{ hashFiles('**/Cargo.lock') }}-${{ github.run_id }}
-          restore-keys: |
-            sccache-build-${{ matrix.arch }}-${{ hashFiles('**/Cargo.lock') }}-
-            sccache-build-${{ matrix.arch }}-
-      - uses: mozilla-actions/sccache-action@v0.0.10
+      - uses: Swatinem/rust-cache@v2
 
       - name: Install build dependencies
         run: |
@@ -73,7 +70,8 @@ jobs:
         run: cargo run --locked --bin koca -- create koca.koca --output-type all --noconfirm
 
       - name: Collect binary
-        run: cp "koca-build/src/koca/target/$(uname -m)-unknown-linux-musl/release/koca" "koca-linux-${{ matrix.arch }}"
+        # Built into the shared CARGO_TARGET_DIR (see env above).
+        run: cp "${CARGO_TARGET_DIR}/$(uname -m)-unknown-linux-musl/release/koca" "koca-linux-${{ matrix.arch }}"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,10 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  SCCACHE_DIR: ${{ github.workspace }}/.sccache
-  RUSTC_WRAPPER: "sccache"
+  # Standardized target dir across all koca workflows; matches the path
+  # Swatinem/rust-cache globs (<workspace>/target) by default. See
+  # release-tag.yml for why this also matters for koca's nested build.
+  CARGO_TARGET_DIR: ${{ github.workspace }}/target
   CARGO_INCREMENTAL: "0"
 
 jobs:
@@ -29,7 +31,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@stable
-      - uses: mozilla-actions/sccache-action@v0.0.10
+      - uses: Swatinem/rust-cache@v2
       - id: release-plz
         uses: release-plz/action@v0.5
         with:

--- a/koca.koca
+++ b/koca.koca
@@ -24,5 +24,6 @@ build() {
 package() {
     cd "${pkgname}/"
     target="$(uname -m)-unknown-linux-musl"
-    install -Dm 755 "target/${target}/release/koca" "${pkgdir}/usr/bin/koca"
+    target_dir="$(cargo metadata --format-version 1 --no-deps | jq -r '.target_directory')"
+    install -Dm 755 "${target_dir}/${target}/release/koca" "${pkgdir}/usr/bin/koca"
 }


### PR DESCRIPTION
## What

Replaces the hand-rolled sccache caching with [`Swatinem/rust-cache@v2`](https://github.com/Swatinem/rust-cache) across all four workflows, matching the `rfpm` and `repology-rs` sibling projects.

## Why

- **Less to maintain.** Drops `RUSTC_WRAPPER`/`SCCACHE_DIR`, the `mozilla-actions/sccache-action` steps, and the manual `actions/cache` blocks with their bespoke key/restore-key logic. rust-cache handles cache keying, registry/git caching, and pruning automatically.
- **Caches the package build.** koca builds its own package by shelling out to `cargo`. Pinning `CARGO_TARGET_DIR` to `<workspace>/target` makes that nested build (previously isolated in `koca-build/src/koca/target`) land in the same tree rust-cache globs by default — so it's actually cached, and deps compile once.

## Notes

- `koca.koca`'s `package()` now resolves the binary via `cargo metadata` instead of assuming `./target`, so packaging works whether or not `CARGO_TARGET_DIR` is set (CI vs. a plain end-user build). This adds a `jq` requirement at package time — already present on CI runners.
- `CARGO_INCREMENTAL: "0"` is retained: it's recommended with rust-cache (incremental artifacts bloat the cache and don't help in CI).
- The `fmt` job no longer sets up any cache — it only runs `cargo fmt --check`, which doesn't compile.